### PR TITLE
Add missing iterator interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootedTrees"
 uuid = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 authors = ["Hendrik Ranocha <h.ranocha@tu-bs.de>"]
-version = "0.0.2"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ julia> butcher_representation(t)
 A `RootedTreeIterator(order::Integer)` can be used to iterate efficiently
 over all `RootedTree`s of a given `order`.
 
+Be careful that the iterator is stateful for efficiency reasons, so you might
+need to use `copy` appropriately, e.g.
+```julia
+julia> map(identity, RootedTreeIterator(4))
+4-element Array{RootedTrees.RootedTree{Int64,Array{Int64,1}},1}:
+ RootedTree{Int64}: [1, 2, 2, 2]
+ RootedTree{Int64}: [1, 2, 2, 2]
+ RootedTree{Int64}: [1, 2, 2, 2]
+ RootedTree{Int64}: [1, 2, 2, 2]
+
+julia> map(copy, RootedTreeIterator(4))
+4-element Array{RootedTrees.RootedTree{Int64,Array{Int64,1}},1}:
+ RootedTree{Int64}: [1, 2, 3, 4]
+ RootedTree{Int64}: [1, 2, 3, 3]
+ RootedTree{Int64}: [1, 2, 3, 2]
+ RootedTree{Int64}: [1, 2, 2, 2]
+```
+
 ### Functions on Trees
 
 The usual functions on `RootedTree`s are implemented, cf.

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -157,6 +157,8 @@ struct RootedTreeIterator{T<:Integer}
   end
 end
 
+Base.IteratorSize(::Type{<:RootedTreeIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{RootedTreeIterator{T}}) where T = RootedTree{T,Vector{T}}
 
 function iterate(iter::RootedTreeIterator{T}) where {T}
   iter.t.level_sequence[:] = one(T):iter.order

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,10 +217,11 @@ A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
 b = @SArray [1/6, 1/6, 2/3]
 c = A * SVector(1, 1, 1)
 for order in 1:3
-  for t in RootedTreeIterator(order)
-    @test residual_order_condition(t, A, b, c) ≈ 0 atol=eps()
-  end
+    @test all(RootedTreeIterator(order)) do t
+        abs(residual_order_condition(t, A, b, c)) < eps()
+    end
 end
+
 let order=4
   res = 0.
   for t in RootedTreeIterator(order)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,9 +217,9 @@ A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
 b = @SArray [1/6, 1/6, 2/3]
 c = A * SVector(1, 1, 1)
 for order in 1:3
-    @test all(RootedTreeIterator(order)) do t
-        abs(residual_order_condition(t, A, b, c)) < eps()
-    end
+  @test all(RootedTreeIterator(order)) do t
+    abs(residual_order_condition(t, A, b, c)) < eps()
+  end
 end
 
 let order=4


### PR DESCRIPTION
This PR makes `RootedTreeIterator` work with functions like `map` and `all`.