### PR TITLE
equality and hashes with equivalence classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ many breaking changes in the near future.
 ### Construction
 
 `RootedTree`s are represented using level sequences, i.e., `AbstractVector`s
-containing the distances of the nodes from the root, cf.
-Beyer, Terry, and Sandra Mitchell Hedetniemi.
-"Constant time generation of rooted trees."
-SIAM Journal on Computing 9.4 (1980): 706-712.
+containing the distances of the nodes from the root, see
+
+- Beyer, Terry, and Sandra Mitchell Hedetniemi.
+  "Constant time generation of rooted trees."
+  SIAM Journal on Computing 9.4 (1980): 706-712.
+
 `RootedTree`s can be constructed from their level sequence using
 ```julia
 julia> t = rootedtree([1, 2, 3, 2])

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -113,10 +113,18 @@ end
 """
     isless(t1::RootedTree, t2::RootedTree)
 
-Compares two rooted trees using a lexicographical comparison of their level sequences.
+Compares two rooted trees using a lexicographical comparison of their level
+sequences while considering equivalence classes given by different root indices.
 """
 function Base.isless(t1::RootedTree, t2::RootedTree)
-  isless(t1.level_sequence, t2.level_sequence)
+  root1 = first(t1.level_sequence)
+  root2 = first(t2.level_sequence)
+  for (e1, e2) in zip(t1.level_sequence, t2.level_sequence)
+    v1 = e1 - root1
+    v2 = e2 - root2
+    v1 == v2 || return isless(v1, v2)
+  end
+  return isless(length(t1.level_sequence), length(t2.level_sequence))
 end
 
 """

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -117,6 +117,19 @@ Compares two rooted trees using a lexicographical comparison of their level
 sequences while considering equivalence classes given by different root indices.
 """
 function Base.isless(t1::RootedTree, t2::RootedTree)
+  if isempty(t1.level_sequence)
+    if isempty(t2.level_sequence)
+      # empty trees are equal
+      return false
+    else
+      # the empty tree `isless` than any other tree
+      return true
+    end
+  elseif isempty(t2.level_sequence)
+    # the empty tree `isless` than any other tree
+    return false
+  end
+
   root1 = first(t1.level_sequence)
   root2 = first(t2.level_sequence)
   for (e1, e2) in zip(t1.level_sequence, t2.level_sequence)
@@ -152,6 +165,11 @@ false
 function Base.:(==)(t1::RootedTree, t2::RootedTree)
   length(t1.level_sequence) == length(t2.level_sequence) || return false
 
+  if isempty(t1.level_sequence)
+    # empty trees are equal
+    return true
+  end
+
   root1 = first(t1.level_sequence)
   root2 = first(t2.level_sequence)
   for (e1, e2) in zip(t1.level_sequence, t2.level_sequence)
@@ -161,8 +179,10 @@ function Base.:(==)(t1::RootedTree, t2::RootedTree)
   return true
 end
 
+
 # Factor out equivalence classes given by different roots
 function Base.hash(t::RootedTree, h::UInt)
+  isempty(t.level_sequence) && return h
   root = first(t.level_sequence)
   for l in t.level_sequence
     h = hash(l - root, h)

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -5,8 +5,6 @@ module RootedTrees
 
 using LinearAlgebra
 
-import Base: show, isless, ==, iterate, copy
-
 
 export rootedtree, rootedtree!, RootedTreeIterator
 
@@ -75,7 +73,7 @@ rootedtree!(level_sequence::AbstractVector) = canonical_representation!(RootedTr
 iscanonical(t::RootedTree) = t.iscanonical
 #TODO: Validate rooted tree in constructor?
 
-copy(t::RootedTree) = RootedTree(copy(t.level_sequence), t.iscanonical)
+Base.copy(t::RootedTree) = RootedTree(copy(t.level_sequence), t.iscanonical)
 
 
 #  #function RootedTree(sequence::Vector{T}, valid::Bool)
@@ -104,7 +102,7 @@ copy(t::RootedTree) = RootedTree(copy(t.level_sequence), t.iscanonical)
 #RootedTree{T<:Integer}(sequence::Vector{T}) = RootedTree{T}(sequence, false)
 
 
-function show(io::IO, t::RootedTree{T}) where {T}
+function Base.show(io::IO, t::RootedTree{T}) where {T}
   print(io, "RootedTree{", T, "}: ")
   show(io, t.level_sequence)
 end
@@ -117,7 +115,7 @@ end
 
 Compares two rooted trees using a lexicographical comparison of their level sequences.
 """
-function isless(t1::RootedTree, t2::RootedTree)
+function Base.isless(t1::RootedTree, t2::RootedTree)
   isless(t1.level_sequence, t2.level_sequence)
 end
 
@@ -143,7 +141,7 @@ julia> t1 == t3
 false
 ```
 """
-function ==(t1::RootedTree, t2::RootedTree)
+function Base.:(==)(t1::RootedTree, t2::RootedTree)
   length(t1.level_sequence) == length(t2.level_sequence) || return false
 
   root1 = first(t1.level_sequence)
@@ -153,6 +151,15 @@ function ==(t1::RootedTree, t2::RootedTree)
   end
 
   return true
+end
+
+# Factor out equivalence classes given by different roots
+function Base.hash(t::RootedTree, h::UInt)
+  root = first(t.level_sequence)
+  for l in t.level_sequence
+    h = hash(l - root, h)
+  end
+  return h
 end
 
 
@@ -223,12 +230,12 @@ end
 Base.IteratorSize(::Type{<:RootedTreeIterator}) = Base.SizeUnknown()
 Base.eltype(::Type{RootedTreeIterator{T}}) where T = RootedTree{T,Vector{T}}
 
-function iterate(iter::RootedTreeIterator{T}) where {T}
+function Base.iterate(iter::RootedTreeIterator{T}) where {T}
   iter.t.level_sequence[:] = one(T):iter.order
   (iter.t, false)
 end
 
-function iterate(iter::RootedTreeIterator{T}, state) where {T}
+function Base.iterate(iter::RootedTreeIterator{T}, state) where {T}
   state && return nothing
 
   two = iter.t.level_sequence[1] + one(T)

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -121,8 +121,38 @@ function isless(t1::RootedTree, t2::RootedTree)
   isless(t1.level_sequence, t2.level_sequence)
 end
 
+"""
+    ==(t1::RootedTree, t2::RootedTree)
+
+Compares two rooted trees based on their level sequences while considering
+equivalence classes given by different root indices.
+
+# Examples
+
+```jldoctest
+julia> t1 = rootedtree([1, 2, 3]);
+
+julia> t2 = rootedtree([2, 3, 4]);
+
+julia> t3 = rootedtree([1, 2, 2]);
+
+julia> t1 == t2
+true
+
+julia> t1 == t3
+false
+```
+"""
 function ==(t1::RootedTree, t2::RootedTree)
-  t1.level_sequence == t2.level_sequence
+  length(t1.level_sequence) == length(t2.level_sequence) || return false
+
+  root1 = first(t1.level_sequence)
+  root2 = first(t2.level_sequence)
+  for (e1, e2) in zip(t1.level_sequence, t2.level_sequence)
+    e1 - root1 == e2 - root2 || return false
+  end
+
+  return true
 end
 
 

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -3,7 +3,7 @@ module RootedTrees
 @doc read(joinpath(dirname(@__DIR__), "README.md"), String) RootedTrees
 
 
-using LinearAlgebra
+using LinearAlgebra: dot
 
 
 export rootedtree, rootedtree!, RootedTreeIterator

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Test
 using StaticArrays
 using RootedTrees
 
+@testset "RootedTrees" begin
+
 @testset "comparisons etc." begin
   trees = (rootedtree([1, 2, 3]),
            rootedtree([1, 2, 3]),
@@ -424,4 +426,18 @@ end
 
   @test forests == reference_forests
   @test skeletons == reference_skeletons
+
+  partitions = collect(PartitionIterator(t))
+  iterator_forests = map(first, partitions)
+  iterator_skeletons = map(last, partitions)
+  for forest in iterator_forests
+    sort!(forest)
+  end
+  sort!(iterator_forests)
+  sort!(iterator_skeletons)
+  @test iterator_forests == forests
+  @test iterator_skeletons == skeletons
 end
+
+
+end # @testset "RootedTrees"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,16 +3,25 @@ using StaticArrays
 using RootedTrees
 
 @testset "comparisons etc." begin
-  trees_array = (rootedtree([1,2,3]),
-                rootedtree([1,2,3]),
-                rootedtree([1,2,2]),
-                rootedtree([1,2,3,3]))
+  trees = (rootedtree([1, 2, 3]),
+           rootedtree([1, 2, 3]),
+           rootedtree([1, 2, 2]),
+           rootedtree([1, 2, 3, 3]))
+  trees_shifted = (rootedtree([1, 2, 3]),
+                   rootedtree([2, 3, 4]),
+                   rootedtree([1, 2, 2]),
+                   rootedtree([1, 2, 3, 3]))
 
-  for (t1,t2,t3,t4) in (trees_array,)
+  for (t1,t2,t3,t4) in (trees, trees_shifted)
     @test t1 == t1
     @test t1 == t2
     @test !(t1 == t3)
     @test !(t1 == t4)
+
+    @test hash(t1) == hash(t1)
+    @test hash(t1) == hash(t2)
+    @test !(hash(t1) == hash(t3))
+    @test !(hash(t1) == hash(t4))
 
     @test t3 < t2    && t2 > t3
     @test !(t2 < t3) && !(t3 > t2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,22 +6,34 @@ using RootedTrees
   trees = (rootedtree([1, 2, 3]),
            rootedtree([1, 2, 3]),
            rootedtree([1, 2, 2]),
-           rootedtree([1, 2, 3, 3]))
+           rootedtree([1, 2, 3, 3]),
+           rootedtree(Int[]))
   trees_shifted = (rootedtree([1, 2, 3]),
                    rootedtree([2, 3, 4]),
                    rootedtree([1, 2, 2]),
-                   rootedtree([1, 2, 3, 3]))
+                   rootedtree([1, 2, 3, 3]),
+                   rootedtree(Int[]))
 
-  for (t1,t2,t3,t4) in (trees, trees_shifted)
+  for (t1,t2,t3,t4,t5) in (trees, trees_shifted)
     @test t1 == t1
     @test t1 == t2
     @test !(t1 == t3)
     @test !(t1 == t4)
+    @test !(t1 == t5)
+    @test !(t2 == t5)
+    @test !(t3 == t5)
+    @test !(t4 == t5)
+    @test t5 == t5
 
     @test hash(t1) == hash(t1)
     @test hash(t1) == hash(t2)
     @test !(hash(t1) == hash(t3))
     @test !(hash(t1) == hash(t4))
+    @test hash(t1) != hash(t5)
+    @test hash(t2) != hash(t5)
+    @test hash(t3) != hash(t5)
+    @test hash(t4) != hash(t5)
+    @test hash(t5) == hash(t5)
 
     @test !(t1 < t1)
     @test !(t1 < t2)
@@ -34,6 +46,10 @@ using RootedTrees
     @test !(t4 < t1) && !(t1 > t4)
     @test t1 <= t2   && t2 >= t1
     @test t2 <= t2   && t2 >= t2
+    @test t5 < t1
+    @test t1 > t5
+    @test !(t5 < t5)
+    @test !(t1 < t5)
 
     println(devnull, t1)
     println(devnull, t2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,11 @@ using RootedTrees
     @test !(hash(t1) == hash(t3))
     @test !(hash(t1) == hash(t4))
 
+    @test !(t1 < t1)
+    @test !(t1 < t2)
+    @test !(t2 < t1)
+    @test !(t1 > t2)
+    @test !(t2 > t1)
     @test t3 < t2    && t2 > t3
     @test !(t2 < t3) && !(t3 > t2)
     @test t1 < t4    && t4 > t1


### PR DESCRIPTION
This considers rooted trees to be equal ignoring isomorphisms introduced by adding the same number to everything in their level sequence. This is technically a breaking change but appears to be very useful for B-series, where rooted trees are used as indices (which may be realized using `OrderedDict`s from https://github.com/JuliaCollections/OrderedCollections.jl). I will prototype such an approach first in https://github.com/ranocha/BSeries.jl. If it works as I expect, I would like to merge this PR and release a new major version of RootedTrees.jl (after writing down the breaking change somewhere).