### PR TITLE
recursion to iteration

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -309,6 +309,8 @@ end
                         rootedtree([4]),
                         rootedtree([3])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 2])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -319,6 +321,8 @@ end
                         rootedtree([2, 3, 4]),
                         rootedtree([1])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 3])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -330,6 +334,8 @@ end
                         rootedtree([2, 3]),
                         rootedtree([1])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 3, 3])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -340,6 +346,8 @@ end
                         rootedtree([2]),
                         rootedtree([1, 2, 2])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 2])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -351,6 +359,8 @@ end
                         rootedtree([2]),
                         rootedtree([1, 2])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 3, 2])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -359,6 +369,8 @@ end
     edge_set = [true, true, true, true]
     reference_forest = [rootedtree([1, 2, 3, 2, 2])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -369,6 +381,8 @@ end
                         rootedtree([2]),
                         rootedtree([1, 2, 3])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 3])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -380,6 +394,8 @@ end
                         rootedtree([2]),
                         rootedtree([1])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 2, 3])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -390,6 +406,8 @@ end
                         rootedtree([2, 3, 3]),
                         rootedtree([1])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2, 3])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end
@@ -400,6 +418,8 @@ end
     reference_forest = [rootedtree([1, 2, 3, 2]),
                         rootedtree([3])]
     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
     reference_skeleton = rootedtree([1, 2])
     @test reference_skeleton == partition_skeleton(t, edge_set)
   end


### PR DESCRIPTION
On `main`:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 10 samples with 1 evaluatio
[ Info: Precompiling RootedTrees [47965b36-3f3e-11e9-0dcf-4570dfd42a8c]
[ Info: Precompiling BSeries [ebb8d67c-85b4-416c-b05f-5f409e808f32]n.
 Range (min … max):  514.573 ms … 526.335 ms  ┊ GC (min … max): 1.90% … 2.41%
 Time  (median):     518.093 ms               ┊ GC (median):    2.01%
 Time  (mean ± σ):   518.897 ms ±   3.846 ms  ┊ GC (mean ± σ):  2.12% ± 0.23%

  █ ▁              ▁█      ▁            ▁   ▁                 ▁  
  █▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁██▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  515 ms           Histogram: frequency by time          526 ms <

 Memory estimate: 196.16 MiB, allocs estimate: 2973632.
BenchmarkTools.Trial: 10 samples with 1 evaluation.
 Range (min … max):  526.034 ms … 532.761 ms  ┊ GC (min … max): 2.60% … 3.27%
 Time  (median):     528.702 ms               ┊ GC (median):    2.65%
 Time  (mean ± σ):   528.870 ms ±   2.176 ms  ┊ GC (mean ± σ):  2.87% ± 0.32%

  █    █ █      █      █    █        █ █          █           █  
  █▁▁▁▁█▁█▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█ ▁
  526 ms           Histogram: frequency by time          533 ms <

 Memory estimate: 196.27 MiB, allocs estimate: 2973651.
```

Using iteration instead of recursion in `partition_forest`:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 11 samples with 1 evaluation.
 Range (min … max):  455.338 ms … 461.239 ms  ┊ GC (min … max): 2.29% … 2.41%
 Time  (median):     457.962 ms               ┊ GC (median):    2.43%
 Time  (mean ± σ):   457.656 ms ±   1.890 ms  ┊ GC (mean ± σ):  2.57% ± 0.30%

  ██  █     █   █            █   █ █    █  █                  █  
  ██▁▁█▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁█▁▁▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  455 ms           Histogram: frequency by time          461 ms <

 Memory estimate: 196.16 MiB, allocs estimate: 2973632.
BenchmarkTools.Trial: 11 samples with 1 evaluation.
 Range (min … max):  465.017 ms … 472.147 ms  ┊ GC (min … max): 2.55% … 3.23%
 Time  (median):     468.323 ms               ┊ GC (median):    2.68%
 Time  (mean ± σ):   467.994 ms ±   2.519 ms  ┊ GC (mean ± σ):  2.86% ± 0.32%

  ▁   ▁  █▁                   ▁▁▁                  ▁   ▁      ▁  
  █▁▁▁█▁▁██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁█ ▁
  465 ms           Histogram: frequency by time          472 ms <

 Memory estimate: 196.27 MiB, allocs estimate: 2973651.
```

Using the `PartitionForestIterator` in the `PartitionIterator`:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  405.987 ms … 419.665 ms  ┊ GC (min … max): 1.26% … 1.38%
 Time  (median):     407.149 ms               ┊ GC (median):    1.32%
 Time  (mean ± σ):   408.615 ms ±   3.711 ms  ┊ GC (mean ± σ):  1.42% ± 0.20%

  █▁▁▁▁▁▁   ▁   ▁  ▁      ▁                                   ▁  
  ███████▁▁▁█▁▁▁█▁▁█▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  406 ms           Histogram: frequency by time          420 ms <

 Memory estimate: 145.27 MiB, allocs estimate: 2973485.
BenchmarkTools.Trial: 12 samples with 1 evaluation.
 Range (min … max):  414.561 ms … 429.649 ms  ┊ GC (min … max): 1.41% … 1.56%
 Time  (median):     416.205 ms               ┊ GC (median):    1.45%
 Time  (mean ± σ):   417.728 ms ±   4.513 ms  ┊ GC (mean ± σ):  1.56% ± 0.20%

  █                                                              
  █▆▆▁▁▁▁▁▁▁▆▆▁▆▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆ ▁
  415 ms           Histogram: frequency by time          430 ms <

 Memory estimate: 145.38 MiB, allocs estimate: 2973504.
```