### PR TITLE
buffer for PartitionIterator

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,7 +72,7 @@ Plots.unicodeplots()
   t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3])
   @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2, 3]
 
-  level_sequence = zeros(Int, RootedTrees.CANONICAL_REPRESENTATION_BUFFER_LENGTH + 1)
+  level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
   level_sequence[1] -= 1
   @inferred rootedtree(level_sequence)
 end
@@ -496,6 +496,11 @@ end
         @test collect(zip(forests, skeletons)) == collect(PartitionIterator(t))
       end
     end
+
+    level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
+    level_sequence[1] -= 1
+    t = rootedtree(level_sequence)
+    @inferred PartitionIterator(t)
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -501,6 +501,8 @@ end
     level_sequence[1] -= 1
     t = rootedtree(level_sequence)
     @inferred PartitionIterator(t)
+    t = @inferred rootedtree!(view(level_sequence, :))
+    @inferred PartitionIterator(t)
   end
 end
 


### PR DESCRIPTION
First benchmarks show no significant influence on runtime. Nevertheless, it reduces allocations in some common workflows, so it's nice to have.