### PR TITLE
use findprev instead of findlast when possible

### DIFF
--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -789,13 +789,26 @@ function all_partitions(t::RootedTree)
   skeletons = [partition_skeleton(t, edge_set)]
 
   for edge_set_value in 1:(2^length(edge_set) - 1)
-    digits!(edge_set, edge_set_value, base=2)
+    binary_digits!(edge_set, edge_set_value)
     push!(forests,   partition_forest(t, edge_set))
     push!(skeletons, partition_skeleton(t, edge_set))
   end
 
   return (; forests, skeletons)
 end
+
+# A helper function to comute the binary representation of an integer `n` as
+# a vector of `Bool`s. This is a more efficient version of
+#   binary_digits!(digits, n) = digits!(digits, n, base=2)
+function binary_digits!(digits::Vector{Bool}, n::Int)
+  bit = 1
+  for i in eachindex(digits)
+    digits[i] = n & bit > 0
+    bit = bit << 1
+  end
+  digits
+end
+
 
 
 """
@@ -856,7 +869,7 @@ function Base.iterate(partitions::PartitionIterator, edge_set_value)
   edge_set     = partitions.edge_set
   edge_set_tmp = partitions.edge_set_tmp
 
-  digits!(edge_set, edge_set_value, base=2)
+  binary_digits!(edge_set, edge_set_value)
 
   # Compute the partition skeleton.
   # The following is a more efficient version of
@@ -919,7 +932,7 @@ function all_splittings(t::RootedTree)
   subtrees = Vector{RootedTree{T, Vector{T}}}() # ordered subtrees
 
   for node_set_value in 0:(2^order(t) - 1)
-    digits!(node_set, node_set_value, base=2)
+    binary_digits!(node_set, node_set_value)
 
     # Check that if a node is removed then all of its descendants are removed
     subtree_root_index = 1
@@ -1001,7 +1014,7 @@ function Base.iterate(splittings::SplittingIterator, node_set_value)
   forest = Vector{RootedTree{T, Vector{T}}}()
 
   while node_set_value <= splittings.max_node_set_value
-    digits!(node_set, node_set_value, base=2)
+    binary_digits!(node_set, node_set_value)
 
     # Check that if a node is removed then all of its descendants are removed
     subtree_root_index = 1

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -682,7 +682,8 @@ function Base.iterate(forest::PartitionForestIterator, state)
   # and `edge_set`.
   deleteat!(level_sequence, subtree_root_index:subtree_last_index)
   deleteat!(edge_set, subtree_root_index-1:subtree_last_index-1)
-  edge_to_remove = findlast(==(false), edge_set)
+
+  edge_to_remove = findprev(==(false), edge_set, edge_to_remove - 1)
   if edge_to_remove === nothing
     edge_to_remove = typemin(Int)
   end
@@ -755,7 +756,7 @@ function partition_skeleton!(level_sequence, edge_set)
     deleteat!(level_sequence, subtree_root_index)
     deleteat!(edge_set, edge_to_contract)
 
-    edge_to_contract = findlast(edge_set)
+    edge_to_contract = findprev(edge_set, edge_to_contract - 1)
   end
 
   # The level sequence `level_sequence` will not automatically be a canonical


### PR DESCRIPTION
On `main`:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  390.405 ms … 407.330 ms  ┊ GC (min … max): 2.65% … 2.64%
 Time  (median):     391.723 ms               ┊ GC (median):    2.75%
 Time  (mean ± σ):   393.572 ms ±   4.565 ms  ┊ GC (mean ± σ):  2.78% ± 0.24%

  ▃  ▃█▃                                                         
  █▁▁███▁▁▁▁▁▁▁▇▁▁▇▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇ ▁
  390 ms           Histogram: frequency by time          407 ms <

 Memory estimate: 145.27 MiB, allocs estimate: 2973485.
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  399.158 ms … 406.041 ms  ┊ GC (min … max): 2.61% … 2.68%
 Time  (median):     400.719 ms               ┊ GC (median):    2.63%
 Time  (mean ± σ):   401.621 ms ±   2.126 ms  ┊ GC (mean ± σ):  2.69% ± 0.21%

  ▁   ▁▁    █▁ ▁▁                █         ▁    ▁             ▁  
  █▁▁▁██▁▁▁▁██▁██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  399 ms           Histogram: frequency by time          406 ms <

 Memory estimate: 145.38 MiB, allocs estimate: 2973504.
```


First commit in this PR:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  386.646 ms … 394.845 ms  ┊ GC (min … max): 2.11% … 2.93%
 Time  (median):     388.391 ms               ┊ GC (median):    2.27%
 Time  (mean ± σ):   389.360 ms ±   2.543 ms  ┊ GC (mean ± σ):  2.40% ± 0.33%

  █ ▁     ▁ █ ▁           ▁ █ ▁                     ▁         ▁  
  █▁█▁▁▁▁▁█▁█▁█▁▁▁▁▁▁▁▁▁▁▁█▁█▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█ ▁
  387 ms           Histogram: frequency by time          395 ms <

 Memory estimate: 145.27 MiB, allocs estimate: 2973485.
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  394.804 ms … 402.930 ms  ┊ GC (min … max): 2.14% … 2.40%
 Time  (median):     398.386 ms               ┊ GC (median):    2.21%
 Time  (mean ± σ):   398.591 ms ±   2.738 ms  ┊ GC (mean ± σ):  2.38% ± 0.32%

  ██       █  █       █    ██  ██      █                 █   ██  
  ██▁▁▁▁▁▁▁█▁▁█▁▁▁▁▁▁▁█▁▁▁▁██▁▁██▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁██ ▁
  395 ms           Histogram: frequency by time          403 ms <

 Memory estimate: 145.38 MiB, allocs estimate: 2973504.
```

Second commit in this PR:
```julia
julia> using RootedTrees, BSeries, BenchmarkTools, StaticArrays

julia> let order = 10
           # explicit midpoint method
           A = @SArray [0 0; 1//2 0]; b = @SArray [0, 1//1]; c = @SArray [0, 1//2];
           display(@benchmark modifying_integrator($A, $b, $c, $order))
           display(@benchmark modified_equation($A, $b, $c, $order))
       end
BenchmarkTools.Trial: 14 samples with 1 evaluation.
 Range (min … max):  367.997 ms … 377.000 ms  ┊ GC (min … max): 2.60% … 2.72%
 Time  (median):     369.319 ms               ┊ GC (median):    2.67%
 Time  (mean ± σ):   370.408 ms ±   2.822 ms  ┊ GC (mean ± σ):  2.67% ± 0.08%

        █           ▃                                            
  ▇▇▁▇▇▁█▁▁▁▇▁▁▁▁▁▇▁█▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▇ ▁
  368 ms           Histogram: frequency by time          377 ms <

 Memory estimate: 145.27 MiB, allocs estimate: 2973485.
BenchmarkTools.Trial: 14 samples with 1 evaluation.
 Range (min … max):  375.526 ms … 387.664 ms  ┊ GC (min … max): 2.55% … 2.61%
 Time  (median):     377.342 ms               ┊ GC (median):    2.58%
 Time  (mean ± σ):   378.124 ms ±   3.015 ms  ┊ GC (mean ± σ):  2.59% ± 0.07%

  ▁▁▁   ██   █ ▁▁▁       ▁                                    ▁  
  ███▁▁▁██▁▁▁█▁███▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  376 ms           Histogram: frequency by time          388 ms <

 Memory estimate: 145.38 MiB, allocs estimate: 2973504.
```