### PR TITLE
first draft of ColoredRootedTree

### DIFF
--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -1325,7 +1325,9 @@ Section 300 of
   John Wiley & Sons, 2008.
 """
 function butcher_representation(t::RootedTree, normalize::Bool=true)
-  if order(t) == 1
+  if order(t) == 0
+    return "∅"
+  elseif order(t) == 1
     return "τ"
   end
 
@@ -1353,7 +1355,7 @@ function butcher_representation(t::RootedTree, normalize::Bool=true)
       n_str = replace(n_str, "8" => "⁸")
       n_str = replace(n_str, "9" => "⁹")
       n_str = replace(n_str, "0" => "⁰")
-      result = replace(result, "τ"^n => "τ"*n_str)
+      result = replace(result, "τ"^n => "τ" * n_str)
     end
   end
 

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -7,6 +7,7 @@ using LinearAlgebra: dot
 
 using Latexify: Latexify
 using RecipesBase: RecipesBase
+using Requires: @require
 
 
 export RootedTree, rootedtree, rootedtree!, RootedTreeIterator,
@@ -379,27 +380,6 @@ function canonical_representation!(t::RootedTree{Int, Vector{Int}})
     buffer = similar(t.level_sequence)
   end
   canonical_representation!(t, buffer)
-end
-
-
-function __init__()
-  # canonical_representation!
-  Threads.resize_nthreads!(CANONICAL_REPRESENTATION_BUFFER,
-                           Vector{Int}(undef, BUFFER_LENGTH))
-
-  # PartitionIterator
-  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T,
-                           Vector{Int}(undef, BUFFER_LENGTH))
-  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE,
-                           Vector{Int}(undef, BUFFER_LENGTH))
-  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON,
-                           Vector{Int}(undef, BUFFER_LENGTH))
-  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET,
-                           Vector{Bool}(undef, BUFFER_LENGTH))
-  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
-                           Vector{Bool}(undef, BUFFER_LENGTH))
-
-  return nothing
 end
 
 
@@ -1365,7 +1345,33 @@ end
 
 include("colored_trees.jl")
 include("latexify.jl")
-include("plots.jl")
+include("plot_recipes.jl")
+
+
+function __init__()
+  # canonical_representation!
+  Threads.resize_nthreads!(CANONICAL_REPRESENTATION_BUFFER,
+                           Vector{Int}(undef, BUFFER_LENGTH))
+
+  # PartitionIterator
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T,
+                           Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE,
+                           Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON,
+                           Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET,
+                           Vector{Bool}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
+                           Vector{Bool}(undef, BUFFER_LENGTH))
+
+  @require Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
+    using .Plots: Plots
+    include("plots.jl")
+  end
+
+  return nothing
+end
 
 
 end # module

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -11,7 +11,7 @@ using Requires: @require
 
 
 export RootedTree, rootedtree, rootedtree!, RootedTreeIterator,
-       ColoredRootedTree, BicoloredRootedTreeIterator
+       ColoredRootedTree, BicoloredRootedTree, BicoloredRootedTreeIterator
 
 export butcher_representation
 
@@ -31,9 +31,6 @@ export RungeKuttaMethod, AdditiveRungeKuttaMethod
 
 
 abstract type AbstractRootedTree end
-
-
-include("time_integration_methods.jl")
 
 
 """
@@ -1193,87 +1190,8 @@ function β(t::AbstractRootedTree)
 end
 
 
-"""
-    elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
-    elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector, c::AbstractVector)
-
-Compute the elementary weight Φ(`t`) of the [`RungeKuttaMethod`](@ref) `rk`
-with Butcher coefficients `A, b, c` for a rooted tree `t``.
-
-Reference: Section 312 of
-- Butcher, John Charles.
-  Numerical methods for ordinary differential equations.
-  John Wiley & Sons, 2008.
-"""
-function elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
-  dot(rk.b, derivative_weight(t, rk))
-end
-
-# TODO: Deprecate also this method?
-function elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector, c::AbstractVector)
-  elementary_weight(t, RungeKuttaMethod(A, b, c))
-end
-
-
-"""
-    derivative_weight(t::RootedTree, rk::RungeKuttaMethod)
-
-Compute the derivative weight (ΦᵢD)(`t`) of the [`RungeKuttaMethod`](@ref) `rk`
-with Butcher coefficients `A, b, c` for the rooted tree `t`.
-
-Reference: Section 312 of
-- Butcher, John Charles.
-  Numerical methods for ordinary differential equations.
-  John Wiley & Sons, 2008.
-"""
-function derivative_weight(t::RootedTree, rk::RungeKuttaMethod)
-  A = rk.A
-  c = rk.c
-
-  # Initialize `result` with the identity element of pointwise multiplication `.*`
-  result = zero(c) .+ one(eltype(c))
-
-  # Iterate over all subtrees and update the `result` using recursion
-  for subtree in SubtreeIterator(t)
-    tmp = A * derivative_weight(subtree, rk)
-    result = result .* tmp
-  end
-
-  return result
-end
-
-# TODO: Deprecations introduced in v2
-@deprecate derivative_weight(t::RootedTree, A, b, c) derivative_weight(t, RungeKuttaMethod(A, b, c))
-
-
-"""
-    residual_order_condition(t::RootedTree, rk::RungeKuttaMethod
-
-The residual of the order condition
-  `(Φ(t) - 1/γ(t)) / σ(t)`
-with [`elementary_weight`](@ref) `Φ(t)`, [`density`](@ref) `γ(t)`, and
-[`symmetry`](@ref) `σ(t)` of the [`RungeKuttaMethod`](@ref) `rk` with Butcher
-coefficients `A, b, c` for the rooted tree `t`.
-
-Reference: Section 315 of
-- Butcher, John Charles.
-  Numerical methods for ordinary differential equations.
-  John Wiley & Sons, 2008.
-"""
-function residual_order_condition(t::RootedTree, rk::RungeKuttaMethod)
-  ew = elementary_weight(t, rk)
-  T = typeof(ew)
-
-  (ew - one(T) / γ(t)) / σ(t)
-end
-
-# TODO: Deprecations introduced in v2
-@deprecate residual_order_condition(t::RootedTree, A, b, c) residual_order_condition(t, RungeKuttaMethod(A, b, c))
-
-
 
 # additional representation and construction methods
-
 """
     t1 ∘ t2
 
@@ -1361,6 +1279,7 @@ end
 include("colored_trees.jl")
 include("latexify.jl")
 include("plot_recipes.jl")
+include("time_integration_methods.jl")
 
 
 function __init__()

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -27,10 +27,13 @@ export partition_forest, PartitionForestIterator,
 
 export all_splittings, SplittingIterator
 
-export RungeKuttaMethod
+export RungeKuttaMethod, AdditiveRungeKuttaMethod
 
 
 abstract type AbstractRootedTree end
+
+
+include("time_integration_methods.jl")
 
 
 """
@@ -1190,56 +1193,12 @@ function β(t::AbstractRootedTree)
 end
 
 
-
-"""
-    RungeKuttaMethod(A, b, c=vec(sum(A, dims=2)))
-
-Represent a Runge-Kutta method with Butcher coefficients `A`, `b`, and `c`.
-If `c` is not provided, the usual "row sum" requirement of consistency with
-autonomous problems is applied.
-"""
-struct RungeKuttaMethod{T, MatT<:AbstractMatrix{T}, VecT<:AbstractVector{T}}
-  A::MatT
-  b::VecT
-  c::VecT
-end
-
-function RungeKuttaMethod(A::AbstractMatrix, b::AbstractVector, c::AbstractVector=vec(sum(A, dims=2)))
-  T = promote_type(eltype(A), eltype(b), eltype(c))
-  _A = T.(A)
-  _b = T.(b)
-  _c = T.(c)
-  return RungeKuttaMethod(_A, _b, _c)
-end
-
-function Base.show(io::IO, rk::RungeKuttaMethod{T}) where {T}
-  print(io, "RungeKuttaMethod{", T, "}")
-  if get(io, :compact, false)
-    print(io, "(")
-    show(io, rk.A)
-    print(io, ", ")
-    show(io, rk.b)
-    print(io, ", ")
-    show(io, rk.c)
-    print(io, ")")
-  else
-    print(io, " with\nA: ")
-    show(io, MIME"text/plain"(), rk.A)
-    print(io, "\nb: ")
-    show(io, MIME"text/plain"(), rk.b)
-    print(io, "\nc: ")
-    show(io, MIME"text/plain"(), rk.c)
-    print(io, "\n")
-  end
-end
-
-
 """
     elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
     elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector, c::AbstractVector)
 
 Compute the elementary weight Φ(`t`) of the [`RungeKuttaMethod`](@ref) `rk`
-with  Butcher coefficients `A, b, c` for a rooted tree `t``.
+with Butcher coefficients `A, b, c` for a rooted tree `t``.
 
 Reference: Section 312 of
 - Butcher, John Charles.

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -11,7 +11,7 @@ using Requires: @require
 
 
 export RootedTree, rootedtree, rootedtree!, RootedTreeIterator,
-       ColoredRootedTree
+       ColoredRootedTree, BicoloredRootedTreeIterator
 
 export butcher_representation
 
@@ -397,7 +397,7 @@ end
 
 
 """
-    RootedTreeIterator{T<:Integer}
+    RootedTreeIterator(order::Integer)
 
 Iterator over all rooted trees of given `order`. The returned trees are views to
 an internal tree modified during the iteration. If the returned trees shall be

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -111,12 +111,12 @@ function Base.isless(t1::ColoredRootedTree, t2::ColoredRootedTree)
   end
 
   root1_minus_root2 = first(t1.level_sequence) - first(t2.level_sequence)
-  for (e1, c1, e2, c2) in zip(t1.level_sequence, t1.color_sequence, t2.level_sequence, t2.color_sequence)
+  for (e1, e2) in zip(t1.level_sequence, t2.level_sequence)
     v1 = e1
     v2 = e2 + root1_minus_root2
-    (v1 == v2 && c1 == c2) || return isless((v1, c1), (v2, c2))
+    (v1 == v2) || return isless(v1, v2)
   end
-  return isless(length(t1.level_sequence), length(t2.level_sequence))
+  return isless(t1.color_sequence, t2.color_sequence)
 end
 
 """

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -297,7 +297,6 @@ function Base.:∘(t1::ColoredRootedTree, t2::ColoredRootedTree)
 end
 
 
-#
 function butcher_representation(t::ColoredRootedTree, normalize::Bool=true;
                                 colormap=_colormap_butcher_representation(t))
   if order(t) == 0

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -1,0 +1,232 @@
+
+"""
+    ColoredRootedTree(level_sequence, color_sequence, is_canonical::Bool=false)
+
+Represents a colored rooted tree using its level sequence. The single-colored
+version is [`RootedTree`](@ref).
+
+# References
+
+- Terry Beyer and Sandra Mitchell Hedetniemi.
+  "Constant time generation of rooted trees".
+  SIAM Journal on Computing 9.4 (1980): 706-712.
+  [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
+- A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
+  "Symplectic Methods Based on Decompositions".
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
+"""
+struct ColoredRootedTree{T<:Integer, V<:AbstractVector{T}, C<:AbstractVector} <: AbstractRootedTree
+  level_sequence::V
+  color_sequence::C
+  iscanonical::Bool
+
+  function ColoredRootedTree(level_sequence::V, color_sequence::C, iscanonical::Bool=false) where {T<:Integer, V<:AbstractVector{T}, C<:AbstractVector}
+    new{T, V, C}(level_sequence, color_sequence, iscanonical)
+  end
+end
+
+"""
+    rootedtree(level_sequence, color_sequence)
+
+Construct a canonical [`ColoredRootedTree`](@ref) object from a `level_sequence`
+and a `color_sequence`, i.e., a vector of integers representing the levels of
+each node of the tree and a vector of associated colors (e.g., `Bool`s or
+`Integers`).
+
+# References
+
+- Terry Beyer and Sandra Mitchell Hedetniemi.
+  "Constant time generation of rooted trees".
+  SIAM Journal on Computing 9.4 (1980): 706-712.
+  [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
+"""
+function rootedtree(level_sequence::AbstractVector, color_sequence::AbstractVector)
+  if axes(level_sequence) != axes(color_sequence)
+    throw(DimensionMismatch("The axes of the `level_sequence` ($level_sequence) and the `color_sequence` ($color_sequence) do not match."))
+  end
+
+  canonical_representation(ColoredRootedTree(level_sequence, color_sequence))
+end
+
+"""
+    rootedtree!(level_sequence, color_sequence)
+
+Construct a canonical [`ColoredRootedTree`](@ref) object from a `level_sequence`
+and a `color_sequence` which may be modified in this process. See also
+[`rootedtree`](@ref).
+
+# References
+
+- Terry Beyer and Sandra Mitchell Hedetniemi.
+  "Constant time generation of rooted trees".
+  SIAM Journal on Computing 9.4 (1980): 706-712.
+  [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
+"""
+rootedtree!(level_sequence::AbstractVector, color_sequence::AbstractVector) = canonical_representation!(ColoredRootedTree(level_sequence, color_sequence))
+
+iscanonical(t::ColoredRootedTree) = t.iscanonical
+#TODO: Validate rooted tree in constructor?
+
+Base.copy(t::ColoredRootedTree) = ColoredRootedTree(copy(t.level_sequence), copy(t.color_sequence), t.iscanonical)
+Base.isempty(t::ColoredRootedTree) = isempty(t.level_sequence)
+Base.empty(t::ColoredRootedTree) = ColoredRootedTree(empty(t.level_sequence), empty(t.color_sequence), iscanonical(t))
+
+
+function Base.show(io::IO, t::ColoredRootedTree{T}) where {T}
+  # print(io, "ColoredRootedTree{", T, "}: [")
+  # if !isempty(t)
+  #   print(io, first(t.level_sequence), " (", first(t.color_sequence), ")")
+  #   for i in Iterators.drop(eachindex(t.level_sequence, t.color_sequence), 1)
+  #     print(io, ", ", t.level_sequence[i], " (", t.color_sequence[i], ")")
+  #   end
+  # end
+  # print(io, "]")
+  print(io, "ColoredRootedTree{", T, "}: ")
+  show(io, (t.level_sequence, t.color_sequence))
+end
+
+
+# comparison
+
+"""
+    isless(t1::ColoredRootedTree, t2::ColoredRootedTree)
+
+Compares two colored rooted trees using a lexicographical comparison of their
+level (first) and color (second) sequences while considering equivalence classes
+given by different root indices.
+"""
+function Base.isless(t1::ColoredRootedTree, t2::ColoredRootedTree)
+  if isempty(t1.level_sequence)
+    if isempty(t2.level_sequence)
+      # empty trees are equal
+      return false
+    else
+      # the empty tree `isless` than any other tree
+      return true
+    end
+  elseif isempty(t2.level_sequence)
+    # the empty tree `isless` than any other tree
+    return false
+  end
+
+  root1_minus_root2 = first(t1.level_sequence) - first(t2.level_sequence)
+  for (e1, c1, e2, c2) in zip(t1.level_sequence, t1.color_sequence, t2.level_sequence, t2.color_sequence)
+    v1 = e1
+    v2 = e2 + root1_minus_root2
+    (v1 == v2 && c1 == c2) || return isless((v1, c1), (v2, c2))
+  end
+  return isless(length(t1.level_sequence), length(t2.level_sequence))
+end
+
+"""
+    ==(t1::ColoredRootedTree, t2::ColoredRootedTree)
+
+Compares two rooted trees based on their level (first) and color (second)
+sequences while considering equivalence classes given by different root indices.
+```
+"""
+function Base.:(==)(t1::ColoredRootedTree, t2::ColoredRootedTree)
+  length(t1.level_sequence) == length(t2.level_sequence) || return false
+
+  if isempty(t1.level_sequence)
+    # empty trees are equal
+    return true
+  end
+
+  root1_minus_root2 = first(t1.level_sequence) - first(t2.level_sequence)
+  for (e1, c1, e2, c2) in zip(t1.level_sequence, t1.color_sequence, t2.level_sequence, t2.color_sequence)
+    v1 = e1
+    v2 = e2 + root1_minus_root2
+    (v1 == v2 && c1 == c2) || return false
+  end
+
+  return true
+end
+
+
+# Factor out equivalence classes given by different roots
+function Base.hash(t::ColoredRootedTree, h::UInt)
+  # TODO: ColoredRootedTree. Use a fast path if possible
+  isempty(t.level_sequence) && return h
+  root = first(t.level_sequence)
+  for (l, c) in zip(t.level_sequence, t.color_sequence)
+    h = hash(l - root, h)
+    h = hash(c, h)
+  end
+  return h
+end
+
+
+# generation and canonical representation
+# TODO: ColoredRootedTree. Performance improvements possible using in-place sort
+function canonical_representation!(t::ColoredRootedTree)
+  subtr = subtrees(t)
+  for i in eachindex(subtr)
+    canonical_representation!(subtr[i])
+  end
+  sort!(subtr, rev=true)
+
+  i = 2
+  for τ in subtr
+    t.level_sequence[i:i+order(τ)-1] = τ.level_sequence
+    i += order(τ)
+  end
+
+  ColoredRootedTree(t.level_sequence, t.color_sequence, true)
+end
+
+
+
+# subtrees
+@inline function Base.iterate(subtrees::SubtreeIterator{<:ColoredRootedTree})
+  subtree_root_index = firstindex(subtrees.t.level_sequence) + 1
+  iterate(subtrees, subtree_root_index)
+end
+
+@inline function Base.iterate(subtrees::SubtreeIterator{<:ColoredRootedTree}, subtree_root_index)
+  level_sequence = subtrees.t.level_sequence
+  color_sequence = subtrees.t.color_sequence
+
+  # terminate the iteration if there are no further subtrees
+  if subtree_root_index > lastindex(level_sequence)
+    return nothing
+  end
+
+  # find the next complete subtree
+  subtree_last_index = _subtree_last_index(subtree_root_index, level_sequence)
+  subtree = ColoredRootedTree(
+    view(level_sequence, subtree_root_index:subtree_last_index),
+    view(color_sequence, subtree_root_index:subtree_last_index),
+    # if t is in canonical representation, its subtrees are, too
+    iscanonical(subtrees.t))
+
+  return (subtree, subtree_last_index + 1)
+end
+
+
+"""
+    subtrees(t::ColoredRootedTree)
+
+Returns a vector of all subtrees of `t`.
+"""
+function subtrees(t::ColoredRootedTree)
+  subtr = typeof(t)[]
+
+  if length(t.level_sequence) < 2
+    return subtr
+  end
+
+  start = 2
+  i = 3
+  while i <= length(t.level_sequence)
+    if t.level_sequence[i] <= t.level_sequence[start]
+      push!(subtr, ColoredRootedTree(t.level_sequence[start:i-1], t.color_sequence[start:i-1]))
+      start = i
+    end
+    i += 1
+  end
+  push!(subtr, ColoredRootedTree(t.level_sequence[start:end], t.color_sequence[start:end]))
+end
+
+

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -1,0 +1,82 @@
+
+RecipesBase.@recipe function plot(t::AbstractRootedTree)
+  # Compute x and y coordinates recursively
+  width = 2.0
+  height = 1.0
+  x, y = _plot_coordinates(t, 0.0, 0.0, width, height)
+
+  # Series properties
+  seriescolor --> :black
+  markershape --> :circle
+  markersize  --> 6
+  linewidth   --> 2
+
+  # Geometric properties
+  grid --> false
+  ticks --> false
+  foreground_color_border --> :white
+  legend --> :bottomright
+
+  # We need to filter out `NaN` since these pollute `extrema`
+  if !isempty(t)
+    x_min, x_max = extrema(Iterators.filter(!isnan, x))
+  else
+    x_min = x_max = zero(eltype(x))
+  end
+  if x_min ≈ x_max
+    xlims --> (x_min - width/2, x_max + width/2)
+  end
+
+  if !isempty(t)
+    y_min, y_max = extrema(Iterators.filter(!isnan, y))
+  else
+    y_min = y_max = zero(eltype(y))
+  end
+  if y_min ≈ y_max
+    ylims --> (y_min - height/2, y_max + height/2)
+  end
+
+  # Annotations
+  label --> "tree " * string(t.level_sequence)
+
+  x, y
+end
+
+function _plot_coordinates(t::AbstractRootedTree,
+                           x_root::T, y_root::T,
+                           width::T,  height::T) where {T}
+  # Indicate a new line series by `NaN`
+  nan = convert(T, NaN)
+
+  # Initialize vectors of return values
+  x = Vector{typeof(x_root)}()
+  y = Vector{typeof(y_root)}()
+
+  if isempty(t)
+    return x, y
+  end
+
+  push!(x, x_root)
+  push!(y, y_root)
+
+  # Compute plot coordinates recursively
+  subtr = subtrees(t)
+
+  # Distribute children uniformly in x and at equal y coordinates
+  y_child = y_root + height
+  num_children = length(subtr)
+  distance = width * (num_children - 1) / 2
+
+  x_children = range(x_root - distance, x_root + distance, length=num_children)
+  for idx in eachindex(subtr)
+    x_child = x_children[idx]
+    push!(x, nan, x_root, x_child)
+    push!(y, nan, y_root, y_child)
+    x_recursive, y_recursive = _plot_coordinates(subtr[idx],
+      x_child, y_child, width / 3, height)
+    append!(x, x_recursive)
+    append!(y, y_recursive)
+  end
+
+  return x, y
+end

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -1,12 +1,20 @@
 
-RecipesBase.@recipe function plot(t::RootedTree)
+RecipesBase.@recipe function plot(t::ColoredRootedTree)
   # Compute x and y coordinates recursively
   width = 2.0
   height = 1.0
-  x, y = _plot_coordinates(t, 0.0, 0.0, width, height)
+  color_idx = unique(t.color_sequence)
+  color_val = Plots.distinguishable_colors(length(color_idx))
+  colormap = Dict{eltype(color_idx), eltype(color_val)}()
+  for (idx, val) in zip(color_idx, color_val)
+    colormap[idx] = val
+  end
+  x, y, colors = _plot_coordinates(t, 0.0, 0.0, width, height, colormap)
 
   # Series properties
-  seriescolor --> :black
+  linecolor --> :black
+  markercolor --> reshape(colors, 1, :)
+  background_color --> "light gray"
   markershape --> :circle
   markersize  --> 6
   linewidth   --> 2
@@ -17,29 +25,87 @@ RecipesBase.@recipe function plot(t::RootedTree)
   foreground_color_border --> :white
   legend --> :bottomright
 
-  # We need to filter out `NaN` since these pollute `extrema`
-  x_min, x_max = extrema(Iterators.filter(!isnan, x))
+  # We need to `flatten` nested arrays
+  if !isempty(t)
+    x_min, x_max = extrema(Iterators.flatten(x))
+  else
+    x_min = x_max = zero(eltype(eltype(x)))
+  end
   if x_min ≈ x_max
     xlims --> (x_min - width/2, x_max + width/2)
   end
-  y_min, y_max = extrema(Iterators.filter(!isnan, y))
+
+  if !isempty(t)
+    y_min, y_max = extrema(Iterators.flatten(y))
+  else
+    y_min = y_max = zero(eltype(eltype(x)))
+  end
   if y_min ≈ y_max
     ylims --> (y_min - height/2, y_max + height/2)
   end
 
   # Annotations
-  label --> "tree " * string(t.level_sequence)
+  labels = ones(String, 1, length(colors))
+  if !isempty(t)
+    labels[1] = "tree " * string((t.level_sequence, t.color_sequence))
+  end
+  label --> labels
 
   x, y
 end
 
-function _plot_coordinates(t::AbstractRootedTree,
+function _plot_coordinates(t::ColoredRootedTree,
                            x_root::T, y_root::T,
-                           width::T,  height::T) where {T}
-  # Indicate a new line series by `NaN`
-  nan = convert(T, NaN)
-  x = [x_root]
-  y = [y_root]
+                           width::T,  height::T,
+                           colormap) where {T}
+  # Initialize vectors of return values
+  x = Vector{Vector{T}}()
+  y = Vector{Vector{T}}()
+  colors = Vector{Vector{valtype(colormap)}}()
+
+  if isempty(t)
+    return x, y, colors
+  end
+
+  push!(x, [x_root])
+  push!(y, [y_root])
+  color_root = colormap[first(t.color_sequence)]
+  push!(colors, [color_root])
+
+  # We cannot indicate a new line series by `NaN` since that doesn't work with
+  # colors
+  # ┌ Warning: Indices Base.OneTo(9) of attribute `seriescolor` does not match data indices 3:9.
+  # └ @ Plots ~/.julia/packages/Plots/AJMX6/src/utils.jl:132
+  # ┌ Info: Data contains NaNs or missing values, and indices of `seriescolor` vector do not match data indices.
+  # │ If you intend elements of `seriescolor` to apply to individual NaN-separated segements in the data,
+  # │ pass each segment in a separate vector instead, and use a row vector for `seriescolor`. Legend entries
+  # │ may be suppressed by passing an empty label.
+  # │ For example,
+  # └     plot([1:2,1:3], [[4,5],[3,4,5]], label=["y" ""], seriescolor=[1 2])
+  # ┌ Warning: Indices Base.OneTo(9) of attribute `linecolor` does not match data indices 3:9.
+  # └ @ Plots ~/.julia/packages/Plots/AJMX6/src/utils.jl:132
+  # ┌ Info: Data contains NaNs or missing values, and indices of `linecolor` vector do not match data indices.
+  # │ If you intend elements of `linecolor` to apply to individual NaN-separated segements in the data,
+  # │ pass each segment in a separate vector instead, and use a row vector for `linecolor`. Legend entries
+  # │ may be suppressed by passing an empty label.
+  # │ For example,
+  # └     plot([1:2,1:3], [[4,5],[3,4,5]], label=["y" ""], linecolor=[1 2])
+  # ┌ Warning: Indices Base.OneTo(9) of attribute `fillcolor` does not match data indices 3:9.
+  # └ @ Plots ~/.julia/packages/Plots/AJMX6/src/utils.jl:132
+  # ┌ Info: Data contains NaNs or missing values, and indices of `fillcolor` vector do not match data indices.
+  # │ If you intend elements of `fillcolor` to apply to individual NaN-separated segements in the data,
+  # │ pass each segment in a separate vector instead, and use a row vector for `fillcolor`. Legend entries
+  # │ may be suppressed by passing an empty label.
+  # │ For example,
+  # └     plot([1:2,1:3], [[4,5],[3,4,5]], label=["y" ""], fillcolor=[1 2])
+  # ┌ Warning: Indices Base.OneTo(9) of attribute `markercolor` does not match data indices 3:9.
+  # └ @ Plots ~/.julia/packages/Plots/AJMX6/src/utils.jl:132
+  # ┌ Info: Data contains NaNs or missing values, and indices of `markercolor` vector do not match data indices.
+  # │ If you intend elements of `markercolor` to apply to individual NaN-separated segements in the data,
+  # │ pass each segment in a separate vector instead, and use a row vector for `markercolor`. Legend entries
+  # │ may be suppressed by passing an empty label.
+  # │ For example,
+  # └     plot([1:2,1:3], [[4,5],[3,4,5]], label=["y" ""], markercolor=[1 2])
 
   # Compute plot coordinates recursively
   subtr = subtrees(t)
@@ -52,56 +118,15 @@ function _plot_coordinates(t::AbstractRootedTree,
   x_children = range(x_root - distance, x_root + distance, length=num_children)
   for idx in eachindex(subtr)
     x_child = x_children[idx]
-    push!(x, nan, x_root, x_child)
-    push!(y, nan, y_root, y_child)
-    x_recursive, y_recursive = _plot_coordinates(subtr[idx],
-      x_child, y_child, width / 3, height)
+    push!(x, [x_root, x_child])
+    push!(y, [y_root, y_child])
+    push!(colors, [color_root, colormap[first(subtr[idx].color_sequence)]])
+    x_recursive, y_recursive, colors_recursive = _plot_coordinates(subtr[idx],
+      x_child, y_child, width / 3, height, colormap)
     append!(x, x_recursive)
     append!(y, y_recursive)
+    append!(colors, colors_recursive)
   end
 
-  return x, y
-end
-
-
-
-RecipesBase.@recipe function plot(t::ColoredRootedTree)
-  # Compute x and y coordinates recursively
-  width = 2.0
-  height = 1.0
-  # TODO: ColoredRootedTree. Use distinguishable_colors from Colors.jl?
-  # color_idx = unique(t.color_sequence)
-  # color_val = distinguishable_colors(length(color_idx))
-  # colormap = Dict{eltype(color_idx), eltype(color_val)}()
-  # for (idx, val) in zip(color_idx, color_val)
-  #   colormap[idx] = val
-  # end
-  x, y = _plot_coordinates(t, 0.0, 0.0, width, height)
-
-  # Series properties
-  seriescolor --> :black
-  markershape --> :circle
-  markersize  --> 6
-  linewidth   --> 2
-
-  # Geometric properties
-  grid --> false
-  ticks --> false
-  foreground_color_border --> :white
-  legend --> :bottomright
-
-  # We need to filter out `NaN` since these pollute `extrema`
-  x_min, x_max = extrema(Iterators.filter(!isnan, x))
-  if x_min ≈ x_max
-    xlims --> (x_min - width/2, x_max + width/2)
-  end
-  y_min, y_max = extrema(Iterators.filter(!isnan, y))
-  if y_min ≈ y_max
-    ylims --> (y_min - height/2, y_max + height/2)
-  end
-
-  # Annotations
-  label --> "tree " * string((t.level_sequence, t.color_sequence))
-
-  x, y
+  return x, y, colors
 end

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -33,8 +33,9 @@ RecipesBase.@recipe function plot(t::RootedTree)
   x, y
 end
 
-function _plot_coordinates(t::RootedTree, x_root::T, y_root::T,
-                                          width::T,  height::T) where {T}
+function _plot_coordinates(t::AbstractRootedTree,
+                           x_root::T, y_root::T,
+                           width::T,  height::T) where {T}
   # Indicate a new line series by `NaN`
   nan = convert(T, NaN)
   x = [x_root]
@@ -60,4 +61,47 @@ function _plot_coordinates(t::RootedTree, x_root::T, y_root::T,
   end
 
   return x, y
+end
+
+
+
+RecipesBase.@recipe function plot(t::ColoredRootedTree)
+  # Compute x and y coordinates recursively
+  width = 2.0
+  height = 1.0
+  # TODO: ColoredRootedTree. Use distinguishable_colors from Colors.jl?
+  # color_idx = unique(t.color_sequence)
+  # color_val = distinguishable_colors(length(color_idx))
+  # colormap = Dict{eltype(color_idx), eltype(color_val)}()
+  # for (idx, val) in zip(color_idx, color_val)
+  #   colormap[idx] = val
+  # end
+  x, y = _plot_coordinates(t, 0.0, 0.0, width, height)
+
+  # Series properties
+  seriescolor --> :black
+  markershape --> :circle
+  markersize  --> 6
+  linewidth   --> 2
+
+  # Geometric properties
+  grid --> false
+  ticks --> false
+  foreground_color_border --> :white
+  legend --> :bottomright
+
+  # We need to filter out `NaN` since these pollute `extrema`
+  x_min, x_max = extrema(Iterators.filter(!isnan, x))
+  if x_min ≈ x_max
+    xlims --> (x_min - width/2, x_max + width/2)
+  end
+  y_min, y_max = extrema(Iterators.filter(!isnan, y))
+  if y_min ≈ y_max
+    ylims --> (y_min - height/2, y_max + height/2)
+  end
+
+  # Annotations
+  label --> "tree " * string((t.level_sequence, t.color_sequence))
+
+  x, y
 end

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -1,0 +1,91 @@
+
+"""
+    RungeKuttaMethod(A, b, c=vec(sum(A, dims=2)))
+
+Represent a Runge-Kutta method with Butcher coefficients `A`, `b`, and `c`.
+If `c` is not provided, the usual "row sum" requirement of consistency with
+autonomous problems is applied.
+"""
+struct RungeKuttaMethod{T, MatT<:AbstractMatrix{T}, VecT<:AbstractVector{T}}
+  A::MatT
+  b::VecT
+  c::VecT
+end
+
+function RungeKuttaMethod(A::AbstractMatrix, b::AbstractVector, c::AbstractVector=vec(sum(A, dims=2)))
+  T = promote_type(eltype(A), eltype(b), eltype(c))
+  _A = T.(A)
+  _b = T.(b)
+  _c = T.(c)
+  return RungeKuttaMethod(_A, _b, _c)
+end
+
+function Base.show(io::IO, rk::RungeKuttaMethod{T}) where {T}
+  print(io, "RungeKuttaMethod{", T, "}")
+  if get(io, :compact, false)
+    print(io, "(")
+    show(io, rk.A)
+    print(io, ", ")
+    show(io, rk.b)
+    print(io, ", ")
+    show(io, rk.c)
+    print(io, ")")
+  else
+    print(io, " with\nA: ")
+    show(io, MIME"text/plain"(), rk.A)
+    print(io, "\nb: ")
+    show(io, MIME"text/plain"(), rk.b)
+    print(io, "\nc: ")
+    show(io, MIME"text/plain"(), rk.c)
+    print(io, "\n")
+  end
+end
+
+
+
+"""
+    AdditiveRungeKuttaMethod(rks)
+    AdditiveRungeKuttaMethod(As, bs, cs=map(A -> vec(sum(A, dims=2)), As))
+
+Represent an additive Runge-Kutta method with collections of Butcher
+coefficients `As`, `bs`, and `cs`. Alternatively, you can pass a collection of
+[`RungeKuttaMethod`](@ref)s to the constructor.
+If the `cs` are not provided, the usual "row sum" requirement of consistency
+with autonomous problems is applied.
+
+An additive Runge-Kutta method applied to the ODE problem
+```math
+  u'(t) = \\sum_\nu f^\\nu(u)
+```
+has the form
+```math
+\\begin{aligned}
+  y^i &= u^n + \\Delta t \\sum_\\nu \\sum_j a^\\nu_{i,j} f^\\nu(y^i), \\
+  u^{n+1} &= u^n + \\Delta t \\sum_\\nu \\sum_i b^\\nu_{i} f^\\nu(y^i).
+\\end{aligned}
+```
+
+# References
+
+- A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
+  "Symplectic Methods Based on Decompositions".
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
+"""
+struct AdditiveRungeKuttaMethod{T, RKs<:AbstractVector{<:RungeKuttaMethod{T}}}
+  rks::RKs
+end
+
+function AdditiveRungeKuttaMethod(As, bs, cs=map(A -> vec(sum(A, dims=2)), As))
+  rks = map(RungeKuttaMethod, As, bs, cs)
+  AdditiveRungeKuttaMethod(rks)
+end
+
+function Base.show(io::IO, ark::AdditiveRungeKuttaMethod{T}) where {T}
+  print(io, "AdditiveRungeKuttaMethod{", T, "} with methods\n")
+  for (idx, rk) in enumerate(ark.rks)
+    print(io, idx, ". ")
+    show(io, rk)
+  end
+end
+

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -140,7 +140,7 @@ An additive Runge-Kutta method applied to the ODE problem
 has the form
 ```math
 \\begin{aligned}
-  y^i &= u^n + \\Delta t \\sum_\\nu \\sum_j a^\\nu_{i,j} f^\\nu(y^i), \\
+  y^i &= u^n + \\Delta t \\sum_\\nu \\sum_j a^\\nu_{i,j} f^\\nu(y^i), \\\\
   u^{n+1} &= u^n + \\Delta t \\sum_\\nu \\sum_i b^\\nu_{i} f^\\nu(y^i).
 \\end{aligned}
 ```
@@ -157,7 +157,7 @@ methods, which are applied to partitioned problems of the form
 
 - A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
   "Symplectic Methods Based on Decompositions".
-  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926-1947.
   [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
 """
 struct AdditiveRungeKuttaMethod{T, RKs<:AbstractVector{<:RungeKuttaMethod{T}}}

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -166,10 +166,9 @@ end
 
 function AdditiveRungeKuttaMethod(rks) # if not all RK methods use the same eltype
   T = mapreduce(eltype, promote_type, rks)
-  converter = x -> T.(x)
-  As = map(converter, rk.A for rk in rks)
-  bs = map(converter, rk.b for rk in rks)
-  cs = map(converter, rk.c for rk in rks)
+  As = map(rk -> T.(rk.A), rks)
+  bs = map(rk -> T.(rk.b), rks)
+  cs = map(rk -> T.(rk.c), rks)
   AdditiveRungeKuttaMethod(As, bs, cs)
 end
 

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -42,6 +42,84 @@ function Base.show(io::IO, rk::RungeKuttaMethod{T}) where {T}
 end
 
 
+"""
+    elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
+    elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector, c::AbstractVector)
+
+Compute the elementary weight Φ(`t`) of the [`RungeKuttaMethod`](@ref) `rk`
+with Butcher coefficients `A, b, c` for a rooted tree `t``.
+
+Reference: Section 312 of
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+"""
+function elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
+  dot(rk.b, derivative_weight(t, rk))
+end
+
+# TODO: Deprecate also this method?
+function elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector, c::AbstractVector)
+  elementary_weight(t, RungeKuttaMethod(A, b, c))
+end
+
+
+"""
+    derivative_weight(t::RootedTree, rk::RungeKuttaMethod)
+
+Compute the derivative weight (ΦᵢD)(`t`) of the [`RungeKuttaMethod`](@ref) `rk`
+with Butcher coefficients `A, b, c` for the rooted tree `t`.
+
+Reference: Section 312 of
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+"""
+function derivative_weight(t::RootedTree, rk::RungeKuttaMethod)
+  A = rk.A
+  c = rk.c
+
+  # Initialize `result` with the identity element of pointwise multiplication `.*`
+  result = zero(c) .+ one(eltype(c))
+
+  # Iterate over all subtrees and update the `result` using recursion
+  for subtree in SubtreeIterator(t)
+    tmp = A * derivative_weight(subtree, rk)
+    result = result .* tmp
+  end
+
+  return result
+end
+
+# TODO: Deprecations introduced in v2
+@deprecate derivative_weight(t::RootedTree, A, b, c) derivative_weight(t, RungeKuttaMethod(A, b, c))
+
+
+"""
+    residual_order_condition(t::RootedTree, rk::RungeKuttaMethod)
+
+The residual of the order condition
+  `(Φ(t) - 1/γ(t)) / σ(t)`
+with [`elementary_weight`](@ref) `Φ(t)`, [`density`](@ref) `γ(t)`, and
+[`symmetry`](@ref) `σ(t)` of the [`RungeKuttaMethod`](@ref) `rk` with Butcher
+coefficients `A, b, c` for the rooted tree `t`.
+
+Reference: Section 315 of
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+"""
+function residual_order_condition(t::RootedTree, rk::RungeKuttaMethod)
+  ew = elementary_weight(t, rk)
+  T = typeof(ew)
+
+  (ew - one(T) / γ(t)) / σ(t)
+end
+
+# TODO: Deprecations introduced in v2
+@deprecate residual_order_condition(t::RootedTree, A, b, c) residual_order_condition(t, RungeKuttaMethod(A, b, c))
+
+
 
 """
     AdditiveRungeKuttaMethod(rks)
@@ -87,5 +165,101 @@ function Base.show(io::IO, ark::AdditiveRungeKuttaMethod{T}) where {T}
     print(io, idx, ". ")
     show(io, rk)
   end
+end
+
+
+# Colored trees are used for order conditions of additive Runge-Kutta methods.
+# The function `color_to_index` maps a color to a one-based index of ARK
+# coefficients.
+color_to_index(color::Integer) = Int(color)
+color_to_index(color::Bool) = 1 + color
+
+
+"""
+    elementary_weight(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+
+Compute the elementary weight Φ(`t`) of the [`AdditiveRungeKuttaMethod`](@ref)
+`ark` for a colored rooted tree `t``.
+
+# References
+
+- A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
+  "Symplectic Methods Based on Decompositions".
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+  Section 312
+"""
+function elementary_weight(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+  # TODO: Check number of RK methods in `ark`?
+  if isempty(t)
+    return one(eltype(first(ark.rks).c))
+  else
+    color = first(t.color_sequence)
+    dot(ark.rks[color_to_index(color)].b, derivative_weight(t, ark))
+  end
+end
+
+
+"""
+    derivative_weight(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+
+Compute the derivative weight (ΦᵢD)(`t`) of the [`AdditiveRungeKuttaMethod`](@ref)
+`ark` for the colored rooted tree `t`.
+
+# References
+
+- A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
+  "Symplectic Methods Based on Decompositions".
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+  Section 312
+"""
+function derivative_weight(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+  # Initialize `result` with the identity element of pointwise multiplication `.*`
+  c = first(ark.rks).c
+  result = zero(c) .+ one(eltype(c))
+
+  # Iterate over all subtrees and update the `result` using recursion
+  for subtree in SubtreeIterator(t)
+    A = ark.rks[color_to_index(first(subtree.color_sequence))].A
+    tmp = A * derivative_weight(subtree, ark)
+    result = result .* tmp
+  end
+
+  return result
+end
+
+
+"""
+    residual_order_condition(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+
+The residual of the order condition
+  `(Φ(t) - 1/γ(t)) / σ(t)`
+with [`elementary_weight`](@ref) `Φ(t)`, [`density`](@ref) `γ(t)`, and
+[`symmetry`](@ref) `σ(t)` of the [`AdditiveRungeKuttaMethod`](@ref) `ark`
+for the colored rooted tree `t`.
+
+# References
+
+- A. L. Araujo, A. Murua, and J. M. Sanz-Serna.
+  "Symplectic Methods Based on Decompositions".
+  SIAM Journal on Numerical Analysis 34.5 (1997): 1926–1947.
+  [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
+- Butcher, John Charles.
+  Numerical methods for ordinary differential equations.
+  John Wiley & Sons, 2008.
+  Section 312
+"""
+function residual_order_condition(t::ColoredRootedTree, ark::AdditiveRungeKuttaMethod)
+  ew = elementary_weight(t, ark)
+  T = typeof(ew)
+
+  (ew - one(T) / γ(t)) / σ(t)
 end
 

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -145,6 +145,14 @@ has the form
 \\end{aligned}
 ```
 
+In particular, additive Runge-Kutta methods are a superset of partitioned RK
+methods, which are applied to partitioned problems of the form
+```math
+  u^1'(t) = f^1(u^1, u^2),
+  \\qquad
+  u^2'(t) = f^2(u^1, u^2).
+```
+
 # References
 
 - A. L. Araujo, A. Murua, and J. M. Sanz-Serna.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -800,6 +800,8 @@ end # @testset "ColoredRootedTree"
 
 @testset "plots" begin
   @testset "RootedTree" begin
+    plot(rootedtree(Int[]))
+
     for order in 1:4
       for t in RootedTreeIterator(order)
         plot(t)
@@ -808,7 +810,7 @@ end # @testset "ColoredRootedTree"
   end
 
   @testset "ColoredRootedTree" begin
-    let t = rootedtree(Int[], Int[])
+    let t = rootedtree(Int[], Bool[])
       plot(t)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,6 +586,111 @@ end # @testset "RootedTree"
 
 
 @testset "ColoredRootedTree" begin
+  @testset "comparisons etc." begin
+    trees = (rootedtree([1, 2, 3], [1, 1, 1]),
+             rootedtree([1, 2, 3], [1, 1, 1]),
+             rootedtree([1, 2, 2], [1, 1, 1]),
+             rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
+             rootedtree(Int[], Int[]),
+             rootedtree([1, 2, 3], [1, 1, 2]),
+             rootedtree([1, 2, 3], [1, 2, 1]),
+             rootedtree([1, 2, 3], [1, 2, 2]),
+             rootedtree([1, 2, 2], [2, 2, 2]),)
+    trees_shifted = (rootedtree([1, 2, 3], [1, 1, 1]),
+                     rootedtree([2, 3, 4], [1, 1, 1]),
+                     rootedtree([1, 2, 2], [1, 1, 1]),
+                     rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
+                     rootedtree(Int[], Int[]),
+                     rootedtree([1, 2, 3], [1, 1, 2]),
+                     rootedtree([0, 1, 2], [1, 2, 1]),
+                     rootedtree([2, 3, 4], [1, 2, 2]),
+                     rootedtree([1, 2, 2], [2, 2, 2]),)
+
+    for (t1,t2,t3,t4,t5,t6,t7,t8,t9) in (trees, trees_shifted)
+      @test t1 == t1
+      @test t1 == t2
+      @test !(t1 == t3)
+      @test !(t1 == t4)
+      @test !(t1 == t5)
+      @test !(t2 == t5)
+      @test !(t3 == t5)
+      @test !(t4 == t5)
+      @test t5 == t5
+      @test !(t1 == t6)
+      @test !(t1 == t7)
+      @test !(t1 == t8)
+
+      @test hash(t1) == hash(t1)
+      @test hash(t1) == hash(t2)
+      @test !(hash(t1) == hash(t3))
+      @test !(hash(t1) == hash(t4))
+      @test hash(t1) != hash(t5)
+      @test hash(t2) != hash(t5)
+      @test hash(t3) != hash(t5)
+      @test hash(t4) != hash(t5)
+      @test hash(t5) == hash(t5)
+      @test hash(t1) != hash(t6)
+      @test hash(t1) != hash(t7)
+      @test hash(t1) != hash(t8)
+
+      @test !(t1 < t1)
+      @test !(t1 < t2)
+      @test !(t2 < t1)
+      @test !(t1 > t2)
+      @test !(t2 > t1)
+      @test t3 < t2    && t2 > t3
+      @test !(t2 < t3) && !(t3 > t2)
+      @test t1 < t4    && t4 > t1
+      @test !(t4 < t1) && !(t1 > t4)
+      @test t1 <= t2   && t2 >= t1
+      @test t2 <= t2   && t2 >= t2
+      @test t5 < t1
+      @test t1 > t5
+      @test !(t5 < t5)
+      @test !(t1 < t5)
+      @test t1 < t6
+      @test t1 < t7
+      @test t1 < t8
+      @test t6 < t7
+      @test t6 < t8
+      @test t7 < t8
+      @test !(t1 < t9)
+      @test !(t6 < t9)
+      @test !(t7 < t9)
+      @test !(t8 < t9)
+
+      println(devnull, t1)
+      println(devnull, t2)
+      println(devnull, t3)
+      println(devnull, t4)
+      println(devnull, t5)
+      println(devnull, t6)
+      println(devnull, t7)
+      println(devnull, t8)
+    end
+
+    # more tests of the canonical representation
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2])
+    @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2]
+    @test !isempty(t)
+
+    t = rootedtree([1, 2, 3, 2, 3, 4, 2, 3])
+    @test t.level_sequence == [1, 2, 3, 4, 2, 3, 2, 3]
+    @test !isempty(t)
+
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3])
+    @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2, 3]
+    @test !isempty(t)
+
+    @test isempty(rootedtree(Int[]))
+    @test isempty(empty(t))
+
+    level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
+    level_sequence[1] -= 1
+    @inferred rootedtree(level_sequence)
+  end
+
+
   @testset "functions on trees" begin
     # See Araujo, Murua, and Sanz-Serna (1997), Table 1
     # https://doi.org/10.1137/S0036142995292128

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,630 +9,580 @@ Plots.unicodeplots()
 
 @testset "RootedTrees" begin
 
-@testset "comparisons etc." begin
-  trees = (rootedtree([1, 2, 3]),
-           rootedtree([1, 2, 3]),
-           rootedtree([1, 2, 2]),
-           rootedtree([1, 2, 3, 3]),
-           rootedtree(Int[]))
-  trees_shifted = (rootedtree([1, 2, 3]),
-                   rootedtree([2, 3, 4]),
-                   rootedtree([1, 2, 2]),
-                   rootedtree([1, 2, 3, 3]),
-                   rootedtree(Int[]))
+@testset "RootedTree" begin
+  @testset "comparisons etc." begin
+    trees = (rootedtree([1, 2, 3]),
+            rootedtree([1, 2, 3]),
+            rootedtree([1, 2, 2]),
+            rootedtree([1, 2, 3, 3]),
+            rootedtree(Int[]))
+    trees_shifted = (rootedtree([1, 2, 3]),
+                    rootedtree([2, 3, 4]),
+                    rootedtree([1, 2, 2]),
+                    rootedtree([1, 2, 3, 3]),
+                    rootedtree(Int[]))
 
-  for (t1,t2,t3,t4,t5) in (trees, trees_shifted)
-    @test t1 == t1
-    @test t1 == t2
-    @test !(t1 == t3)
-    @test !(t1 == t4)
-    @test !(t1 == t5)
-    @test !(t2 == t5)
-    @test !(t3 == t5)
-    @test !(t4 == t5)
-    @test t5 == t5
+    for (t1,t2,t3,t4,t5) in (trees, trees_shifted)
+      @test t1 == t1
+      @test t1 == t2
+      @test !(t1 == t3)
+      @test !(t1 == t4)
+      @test !(t1 == t5)
+      @test !(t2 == t5)
+      @test !(t3 == t5)
+      @test !(t4 == t5)
+      @test t5 == t5
 
-    @test hash(t1) == hash(t1)
-    @test hash(t1) == hash(t2)
-    @test !(hash(t1) == hash(t3))
-    @test !(hash(t1) == hash(t4))
-    @test hash(t1) != hash(t5)
-    @test hash(t2) != hash(t5)
-    @test hash(t3) != hash(t5)
-    @test hash(t4) != hash(t5)
-    @test hash(t5) == hash(t5)
+      @test hash(t1) == hash(t1)
+      @test hash(t1) == hash(t2)
+      @test !(hash(t1) == hash(t3))
+      @test !(hash(t1) == hash(t4))
+      @test hash(t1) != hash(t5)
+      @test hash(t2) != hash(t5)
+      @test hash(t3) != hash(t5)
+      @test hash(t4) != hash(t5)
+      @test hash(t5) == hash(t5)
 
-    @test !(t1 < t1)
-    @test !(t1 < t2)
-    @test !(t2 < t1)
-    @test !(t1 > t2)
-    @test !(t2 > t1)
-    @test t3 < t2    && t2 > t3
-    @test !(t2 < t3) && !(t3 > t2)
-    @test t1 < t4    && t4 > t1
-    @test !(t4 < t1) && !(t1 > t4)
-    @test t1 <= t2   && t2 >= t1
-    @test t2 <= t2   && t2 >= t2
-    @test t5 < t1
-    @test t1 > t5
-    @test !(t5 < t5)
-    @test !(t1 < t5)
+      @test !(t1 < t1)
+      @test !(t1 < t2)
+      @test !(t2 < t1)
+      @test !(t1 > t2)
+      @test !(t2 > t1)
+      @test t3 < t2    && t2 > t3
+      @test !(t2 < t3) && !(t3 > t2)
+      @test t1 < t4    && t4 > t1
+      @test !(t4 < t1) && !(t1 > t4)
+      @test t1 <= t2   && t2 >= t1
+      @test t2 <= t2   && t2 >= t2
+      @test t5 < t1
+      @test t1 > t5
+      @test !(t5 < t5)
+      @test !(t1 < t5)
 
-    println(devnull, t1)
-    println(devnull, t2)
-    println(devnull, t3)
-    println(devnull, t4)
-  end
-
-  # more tests of the canonical representation
-  t = rootedtree([1, 2, 3, 2, 3, 3, 2])
-  @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2]
-  @test !isempty(t)
-
-  t = rootedtree([1, 2, 3, 2, 3, 4, 2, 3])
-  @test t.level_sequence == [1, 2, 3, 4, 2, 3, 2, 3]
-  @test !isempty(t)
-
-  t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3])
-  @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2, 3]
-  @test !isempty(t)
-
-  @test isempty(rootedtree(Int[]))
-  @test isempty(empty(t))
-
-  level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
-  level_sequence[1] -= 1
-  @inferred rootedtree(level_sequence)
-end
-
-
-@testset "hashing" begin
-  hashes = [hash(rootedtree(Int[]))]
-  for o in 1:12
-    for t in RootedTreeIterator(o)
-      new_hash = @inferred hash(t)
-      @test !(new_hash in hashes)
-      push!(hashes, new_hash)
+      println(devnull, t1)
+      println(devnull, t2)
+      println(devnull, t3)
+      println(devnull, t4)
     end
-  end
-  t = rootedtree([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 2])
-  new_hash = @inferred hash(t)
-  @test !(new_hash in hashes)
-end
 
+    # more tests of the canonical representation
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2])
+    @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2]
+    @test !isempty(t)
 
-# see Table 301(I) etc. in butcher2016numerical
-@testset "functions on trees" begin
-  t1 = rootedtree([1])
-  @test order(t1) == 1
-  @test σ(t1) == 1
-  @test γ(t1) == 1
-  @test α(t1) == 1
-  @test β(t1) == α(t1)*γ(t1)
-  @test butcher_representation(t1) == "τ"
-  latex_string = "\\rootedtree[]"
-  @test RootedTrees.latexify(t1) == latex_string
-  @test latexify(t1) == latex_string
-  @test isempty(RootedTrees.subtrees(t1))
-  @test RootedTrees.latexify(empty(t1)) == "\\varnothing"
+    t = rootedtree([1, 2, 3, 2, 3, 4, 2, 3])
+    @test t.level_sequence == [1, 2, 3, 4, 2, 3, 2, 3]
+    @test !isempty(t)
 
-  @inferred order(t1)
-  @inferred σ(t1)
-  @inferred γ(t1)
-  @inferred α(t1)
-  @inferred β(t1)
-  @inferred t1 ∘ t1
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3])
+    @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2, 3]
+    @test !isempty(t)
 
-  t2 = rootedtree([1, 2])
-  @test order(t2) == 2
-  @test σ(t2) == 1
-  @test γ(t2) == 2
-  @test α(t2) == 1
-  @test β(t2) == α(t2)*γ(t2)
-  @test t2 == t1 ∘ t1
-  @test butcher_representation(t2) == "[τ]"
-  latex_string = "\\rootedtree[[]]"
-  @test RootedTrees.latexify(t2) == latex_string
-  @test latexify(t2) == latex_string
-  @test RootedTrees.subtrees(t2) == [rootedtree([2])]
-
-  t3 = rootedtree([1, 2, 2])
-  @test order(t3) == 3
-  @test σ(t3) == 2
-  @test γ(t3) == 3
-  @test α(t3) == 1
-  @test β(t3) == α(t3)*γ(t3)
-  @test t3 == t2 ∘ t1
-  @test butcher_representation(t3) == "[τ²]"
-  latex_string = "\\rootedtree[[][]]"
-  @test RootedTrees.latexify(t3) == latex_string
-  @test latexify(t3) == latex_string
-  @test RootedTrees.subtrees(t3) == [rootedtree([2]), rootedtree([2])]
-
-  t4 = rootedtree([1, 2, 3])
-  @test order(t4) == 3
-  @test σ(t4) == 1
-  @test γ(t4) == 6
-  @test α(t4) == 1
-  @test β(t4) == α(t4)*γ(t4)
-  @test t4 == t1 ∘ t2
-  @test butcher_representation(t4) == "[[τ]]"
-  latex_string = "\\rootedtree[[[]]]"
-  @test RootedTrees.latexify(t4) == latex_string
-  @test latexify(t4) == latex_string
-  @test RootedTrees.subtrees(t4) == [rootedtree([2, 3])]
-
-  t5 = rootedtree([1, 2, 2, 2])
-  @test order(t5) == 4
-  @test σ(t5) == 6
-  @test γ(t5) == 4
-  @test α(t5) == 1
-  @test β(t5) == α(t5)*γ(t5)
-  @test t5 == t3 ∘ t1
-  @test butcher_representation(t5) == "[τ³]"
-  @test RootedTrees.subtrees(t5) == [rootedtree([2]), rootedtree([2]), rootedtree([2])]
-
-  t6 = rootedtree([1, 2, 2, 3])
-  @inferred RootedTrees.subtrees(t6)
-  @test order(t6) == 4
-  @test σ(t6) == 1
-  @test γ(t6) == 8
-  @test α(t6) == 3
-  @test β(t6) == α(t6)*γ(t6)
-  @test t6 == t2 ∘ t2 == t4 ∘ t1
-  @test butcher_representation(t6) == "[[τ]τ]"
-  @test RootedTrees.subtrees(t6) == [rootedtree([2, 3]), rootedtree([2])]
-
-  t7 = rootedtree([1, 2, 3, 3])
-  @test order(t7) == 4
-  @test σ(t7) == 2
-  @test γ(t7) == 12
-  @test β(t7) == α(t7)*γ(t7)
-  @test t7 == t1 ∘ t3
-  @test butcher_representation(t7) == "[[τ²]]"
-
-  t8 = rootedtree([1, 2, 3, 4])
-  @test order(t8) == 4
-  @test σ(t8) == 1
-  @test γ(t8) == 24
-  @test α(t8) == 1
-  @test t8 == t1 ∘ t4
-  @test butcher_representation(t8) == "[[[τ]]]"
-
-  t9 = rootedtree([1, 2, 2, 2, 2])
-  @test order(t9) == 5
-  @test σ(t9) == 24
-  @test γ(t9) == 5
-  @test α(t9) == 1
-  @test β(t9) == α(t9)*γ(t9)
-  @test t9 == t5 ∘ t1
-  @test butcher_representation(t9) == "[τ⁴]"
-
-  t10 = rootedtree([1, 2, 2, 2, 3])
-  @test order(t10) == 5
-  @test σ(t10) == 2
-  @test γ(t10) == 10
-  @test α(t10) == 6
-  @test β(t10) == α(t10)*γ(t10)
-  @test t10 == t3 ∘ t2 == t6 ∘ t1
-  @test butcher_representation(t10) == "[[τ]τ²]"
-
-  t11 = rootedtree([1, 2, 2, 3, 3])
-  @test order(t11) == 5
-  @test σ(t11) == 2
-  @test γ(t11) == 15
-  @test α(t11) == 4
-  @test t11 == t2 ∘ t3 == t7 ∘ t1
-  @test butcher_representation(t11) == "[[τ²]τ]"
-
-  t12 = rootedtree([1, 2, 2, 3, 4])
-  @test order(t12) == 5
-  @test σ(t12) == 1
-  @test γ(t12) == 30
-  @test α(t12) == 4
-  @test β(t12) == α(t12)*γ(t12)
-  @test t12 == t2 ∘ t4 == t8 ∘ t1
-  @test butcher_representation(t12) == "[[[τ]]τ]"
-
-  t13 = rootedtree([1, 2, 3, 2, 3])
-  @test order(t13) == 5
-  @test σ(t13) == 2
-  @test γ(t13) == 20
-  @test α(t13) == 3
-  @test β(t13) == α(t13)*γ(t13)
-  @test t13 == t4 ∘ t2
-  @test butcher_representation(t13) == "[[τ][τ]]"
-
-  t14 = rootedtree([1, 2, 3, 3, 3])
-  @test order(t14) == 5
-  @test σ(t14) == 6
-  @test γ(t14) == 20
-  @test α(t14) == 1
-  @test β(t14) == α(t14)*γ(t14)
-  @test t14 == t1 ∘ t5
-  @test butcher_representation(t14) == "[[τ³]]"
-
-  t15 = rootedtree([1, 2, 3, 3, 4])
-  @test order(t15) == 5
-  @test σ(t15) == 1
-  @test γ(t15) == 40
-  @test α(t15) == 3
-  @test β(t15) == α(t15)*γ(t15)
-  @test t15 == t1 ∘ t6
-  @test butcher_representation(t15) == "[[[τ]τ]]"
-
-  t16 = rootedtree([1, 2, 3, 4, 4])
-  @test order(t16) == 5
-  @test σ(t16) == 2
-  @test γ(t16) == 60
-  @test α(t16) == 1
-  @test β(t16) == α(t16)*γ(t16)
-  @test t16 == t1 ∘ t7
-  @test butcher_representation(t16) == "[[[τ²]]]"
-
-  t17 = rootedtree([1, 2, 3, 4, 5])
-  @test order(t17) == 5
-  @test σ(t17) == 1
-  @test γ(t17) == 120
-  @test α(t17) == 1
-  @test β(t17) == α(t17)*γ(t17)
-  @test t17 == t1 ∘ t8
-  @test butcher_representation(t17) == "[[[[τ]]]]"
-
-  # test non-canonical representation
-  level_sequence = [1, 2, 3, 2, 3, 4, 2, 3, 2, 3, 4, 5, 6, 2, 3, 4]
-  @test σ(rootedtree(level_sequence)) == σ(RootedTrees.RootedTree(level_sequence))
-end
-
-
-# see butcher2008numerical, Table 302(I)
-@testset "number of trees" begin
-  number_of_rooted_trees = [1, 1, 2, 4, 9, 20, 48, 115, 286, 719]
-  for order in 1:10
-    num = 0
-    for t in RootedTreeIterator(order)
-      num += 1
-    end
-    @test num == number_of_rooted_trees[order] == count_trees(order)
-  end
-end
-
-# Runge-Kutta method SSPRK33 of order 3
-@testset "Runge-Kutta order conditions" begin
-  A = [0 0 0; 1 0 0; 1/4 1/4 0]
-  b = [1/6, 1/6, 2/3]
-  c = A * fill(1, length(b))
-  for order in 1:3
-    for t in RootedTreeIterator(order)
-      @test residual_order_condition(t, A, b, c) ≈ 0 atol=eps()
-    end
-  end
-  let order=4
-    res = 0.0
-    for t in RootedTreeIterator(order)
-      res += abs(residual_order_condition(t, A, b, c))
-    end
-    @test res > 10*eps()
-  end
-
-  A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
-  b = @SArray [1/6, 1/6, 2/3]
-  c = A * SVector(1, 1, 1)
-  for order in 1:3
-    @test all(RootedTreeIterator(order)) do t
-      abs(residual_order_condition(t, A, b, c)) < eps()
-    end
-  end
-
-  let order=4
-    res = 0.0
-    for t in RootedTreeIterator(order)
-      res += abs(residual_order_condition(t, A, b, c))
-    end
-    @test res > 10*eps()
-  end
-end
-
-# See Section 2.3 and Table 2 of
-# - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
-#   Algebraic Structures of B-series.
-#   Foundations of Computational Mathematics
-#   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
-@testset "partitions" begin
-  let t = rootedtree([1, 2, 3, 4, 3])
-    edge_set = [true, true, false, false]
-    reference_forest = [rootedtree([1, 2, 3]),
-                        rootedtree([4]),
-                        rootedtree([3])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 2])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 4, 3])
-    edge_set = [false, true, true, false]
-    reference_forest = [rootedtree([3]),
-                        rootedtree([2, 3, 4]),
-                        rootedtree([1])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 3])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 4, 3])
-    edge_set = [false, true, false, false]
-    reference_forest = [rootedtree([4]),
-                        rootedtree([3]),
-                        rootedtree([2, 3]),
-                        rootedtree([1])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 3, 3])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 2, 2, 2])
-    edge_set = [false, false, true, true]
-    reference_forest = [rootedtree([2]),
-                        rootedtree([2]),
-                        rootedtree([1, 2, 2])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 2])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 2, 2])
-    edge_set = [false, false, false, true]
-    reference_forest = [rootedtree([3]),
-                        rootedtree([2]),
-                        rootedtree([2]),
-                        rootedtree([1, 2])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 3, 2])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 2, 2])
-    edge_set = [true, true, true, true]
-    reference_forest = [rootedtree([1, 2, 3, 2, 2])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 2, 3])
-    edge_set = [true, true, false, false]
-    reference_forest = [rootedtree([3]),
-                        rootedtree([2]),
-                        rootedtree([1, 2, 3])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 3])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 2, 3])
-    edge_set = [false, true, false, false]
-    reference_forest = [rootedtree([2, 3]),
-                        rootedtree([3]),
-                        rootedtree([2]),
-                        rootedtree([1])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 2, 3])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  let t = rootedtree([1, 2, 3, 3, 3])
-    edge_set = [false, true, true, false]
-    reference_forest = [rootedtree([3]),
-                        rootedtree([2, 3, 3]),
-                        rootedtree([1])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2, 3])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-
-  # additional tests not included in the examples of the paper
-  let t = rootedtree([1, 2, 3, 2, 3])
-    edge_set = [true, false, true, true]
-    reference_forest = [rootedtree([1, 2, 3, 2]),
-                        rootedtree([3])]
-    @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-    @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
-
-    reference_skeleton = rootedtree([1, 2])
-    @test reference_skeleton == partition_skeleton(t, edge_set)
-  end
-end
-
-# See Table 3 of
-# - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
-#   Algebraic Structures of B-series.
-#   Foundations of Computational Mathematics
-#   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
-@testset "all_partitions" begin
-  t = rootedtree([1, 2, 3, 3])
-  forests, skeletons = all_partitions(t)
-  for forest in forests
-    for tree in forest
-      RootedTrees.normalize_root!(tree)
-    end
-    sort!(forest)
-  end
-  sort!(forests)
-  for tree in skeletons
-    RootedTrees.normalize_root!(tree)
-  end
-  sort!(skeletons)
-
-  reference_forests = [
-    [rootedtree([1, 2, 3, 3]),],
-    [rootedtree([1]), rootedtree([1, 2, 2])],
-    [rootedtree([1]), rootedtree([1, 2, 3])],
-    [rootedtree([1]), rootedtree([1, 2, 3]),],
-    [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
-    [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
-    [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
-    [rootedtree([1]), rootedtree([1]), rootedtree([1]), rootedtree([1])],
-  ]
-  reference_skeletons = [
-    rootedtree([1]),
-    rootedtree([1, 2]),
-    rootedtree([1, 2]),
-    rootedtree([1, 2]),
-    rootedtree([1, 2, 2]),
-    rootedtree([1, 2, 3]),
-    rootedtree([1, 2, 3]),
-    rootedtree([1, 2, 3, 3]),
-  ]
-  for forest in reference_forests
-    sort!(forest)
-  end
-  sort!(reference_forests)
-  sort!(reference_skeletons)
-
-  @test forests == reference_forests
-  @test skeletons == reference_skeletons
-
-  @testset "PartitionIterator" begin
-    partitions = collect(PartitionIterator(t))
-    iterator_forests = map(first, partitions)
-    iterator_skeletons = map(last, partitions)
-    for forest in iterator_forests
-      sort!(forest)
-    end
-    sort!(iterator_forests)
-    sort!(iterator_skeletons)
-    @test iterator_forests == forests
-    @test iterator_skeletons == skeletons
-
-    for order in 1:8
-      for t in RootedTreeIterator(order)
-        forests, skeletons = all_partitions(t)
-        @test collect(zip(forests, skeletons)) == collect(PartitionIterator(t))
-      end
-    end
+    @test isempty(rootedtree(Int[]))
+    @test isempty(empty(t))
 
     level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
     level_sequence[1] -= 1
-    t = rootedtree(level_sequence)
-    @inferred PartitionIterator(t)
-    t = @inferred rootedtree!(view(level_sequence, :))
-    @inferred PartitionIterator(t)
+    @inferred rootedtree(level_sequence)
   end
-end
 
 
-# See Section 2.2 and Table 1 of
-# - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
-#   Algebraic Structures of B-series.
-#   Foundations of Computational Mathematics
-#   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
-@testset "splittings" begin
-  t = rootedtree([1, 2, 3, 2, 2])
-  splittings = all_splittings(t)
-  forests_and_subtrees = sort!(collect(zip(splittings.forests, splittings.subtrees)))
+  @testset "hashing" begin
+    hashes = [hash(rootedtree(Int[]))]
+    for o in 1:12
+      for t in RootedTreeIterator(o)
+        new_hash = @inferred hash(t)
+        @test !(new_hash in hashes)
+        push!(hashes, new_hash)
+      end
+    end
+    t = rootedtree([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 2])
+    new_hash = @inferred hash(t)
+    @test !(new_hash in hashes)
+  end
 
-  reference_forests_and_subtrees = sort!([
-    (empty([rootedtree([1])]),                               rootedtree([1, 2, 3, 2, 2])),
-    ([rootedtree([1])],                                      rootedtree([1, 2, 3, 2])),
-    ([rootedtree([1])],                                      rootedtree([1, 2, 3, 2])),
-    ([rootedtree([1, 2])],                                   rootedtree([1, 2, 2])),
-    ([rootedtree([1])],                                      rootedtree([1, 2, 2, 2])),
-    ([rootedtree([1, 2]), rootedtree([1])],                  rootedtree([1, 2])),
-    ([rootedtree([1, 2]), rootedtree([1])],                  rootedtree([1, 2])),
-    ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 3])),
-    ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 2])),
-    ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 2])),
-    ([rootedtree([1]),    rootedtree([1]), rootedtree([1])], rootedtree([1, 2])),
-    ([rootedtree([1, 2]), rootedtree([1]), rootedtree([1])], rootedtree([1])),
-    ([rootedtree([1, 2, 3, 2, 2])],                          rootedtree(Int[])),
-  ])
 
-  @test forests_and_subtrees == reference_forests_and_subtrees
+  # see Table 301(I) etc. in butcher2016numerical
+  @testset "functions on trees" begin
+    t1 = rootedtree([1])
+    @test order(t1) == 1
+    @test σ(t1) == 1
+    @test γ(t1) == 1
+    @test α(t1) == 1
+    @test β(t1) == α(t1)*γ(t1)
+    @test butcher_representation(t1) == "τ"
+    latex_string = "\\rootedtree[]"
+    @test RootedTrees.latexify(t1) == latex_string
+    @test latexify(t1) == latex_string
+    @test isempty(RootedTrees.subtrees(t1))
+    @test RootedTrees.latexify(empty(t1)) == "\\varnothing"
 
-  # tested with the Python package BSeries
-  t = rootedtree([1, 2, 3, 4, 4, 2, 3, 3, 2, 3, 2, 3])
-  splittings = all_splittings(t)
-  @test length(splittings.forests) == length(splittings.subtrees) == 271
+    @inferred order(t1)
+    @inferred σ(t1)
+    @inferred γ(t1)
+    @inferred α(t1)
+    @inferred β(t1)
+    @inferred t1 ∘ t1
 
-  # consistency of all_splittings and the SplittingIterator
-  for order in 1:8
-    for i in RootedTreeIterator(order)
-      forests, subtrees = all_splittings(t)
-      @test collect(zip(forests, subtrees)) == collect(SplittingIterator(t))
+    t2 = rootedtree([1, 2])
+    @test order(t2) == 2
+    @test σ(t2) == 1
+    @test γ(t2) == 2
+    @test α(t2) == 1
+    @test β(t2) == α(t2)*γ(t2)
+    @test t2 == t1 ∘ t1
+    @test butcher_representation(t2) == "[τ]"
+    latex_string = "\\rootedtree[[]]"
+    @test RootedTrees.latexify(t2) == latex_string
+    @test latexify(t2) == latex_string
+    @test RootedTrees.subtrees(t2) == [rootedtree([2])]
+
+    t3 = rootedtree([1, 2, 2])
+    @test order(t3) == 3
+    @test σ(t3) == 2
+    @test γ(t3) == 3
+    @test α(t3) == 1
+    @test β(t3) == α(t3)*γ(t3)
+    @test t3 == t2 ∘ t1
+    @test butcher_representation(t3) == "[τ²]"
+    latex_string = "\\rootedtree[[][]]"
+    @test RootedTrees.latexify(t3) == latex_string
+    @test latexify(t3) == latex_string
+    @test RootedTrees.subtrees(t3) == [rootedtree([2]), rootedtree([2])]
+
+    t4 = rootedtree([1, 2, 3])
+    @test order(t4) == 3
+    @test σ(t4) == 1
+    @test γ(t4) == 6
+    @test α(t4) == 1
+    @test β(t4) == α(t4)*γ(t4)
+    @test t4 == t1 ∘ t2
+    @test butcher_representation(t4) == "[[τ]]"
+    latex_string = "\\rootedtree[[[]]]"
+    @test RootedTrees.latexify(t4) == latex_string
+    @test latexify(t4) == latex_string
+    @test RootedTrees.subtrees(t4) == [rootedtree([2, 3])]
+
+    t5 = rootedtree([1, 2, 2, 2])
+    @test order(t5) == 4
+    @test σ(t5) == 6
+    @test γ(t5) == 4
+    @test α(t5) == 1
+    @test β(t5) == α(t5)*γ(t5)
+    @test t5 == t3 ∘ t1
+    @test butcher_representation(t5) == "[τ³]"
+    @test RootedTrees.subtrees(t5) == [rootedtree([2]), rootedtree([2]), rootedtree([2])]
+
+    t6 = rootedtree([1, 2, 2, 3])
+    @inferred RootedTrees.subtrees(t6)
+    @test order(t6) == 4
+    @test σ(t6) == 1
+    @test γ(t6) == 8
+    @test α(t6) == 3
+    @test β(t6) == α(t6)*γ(t6)
+    @test t6 == t2 ∘ t2 == t4 ∘ t1
+    @test butcher_representation(t6) == "[[τ]τ]"
+    @test RootedTrees.subtrees(t6) == [rootedtree([2, 3]), rootedtree([2])]
+
+    t7 = rootedtree([1, 2, 3, 3])
+    @test order(t7) == 4
+    @test σ(t7) == 2
+    @test γ(t7) == 12
+    @test β(t7) == α(t7)*γ(t7)
+    @test t7 == t1 ∘ t3
+    @test butcher_representation(t7) == "[[τ²]]"
+
+    t8 = rootedtree([1, 2, 3, 4])
+    @test order(t8) == 4
+    @test σ(t8) == 1
+    @test γ(t8) == 24
+    @test α(t8) == 1
+    @test t8 == t1 ∘ t4
+    @test butcher_representation(t8) == "[[[τ]]]"
+
+    t9 = rootedtree([1, 2, 2, 2, 2])
+    @test order(t9) == 5
+    @test σ(t9) == 24
+    @test γ(t9) == 5
+    @test α(t9) == 1
+    @test β(t9) == α(t9)*γ(t9)
+    @test t9 == t5 ∘ t1
+    @test butcher_representation(t9) == "[τ⁴]"
+
+    t10 = rootedtree([1, 2, 2, 2, 3])
+    @test order(t10) == 5
+    @test σ(t10) == 2
+    @test γ(t10) == 10
+    @test α(t10) == 6
+    @test β(t10) == α(t10)*γ(t10)
+    @test t10 == t3 ∘ t2 == t6 ∘ t1
+    @test butcher_representation(t10) == "[[τ]τ²]"
+
+    t11 = rootedtree([1, 2, 2, 3, 3])
+    @test order(t11) == 5
+    @test σ(t11) == 2
+    @test γ(t11) == 15
+    @test α(t11) == 4
+    @test t11 == t2 ∘ t3 == t7 ∘ t1
+    @test butcher_representation(t11) == "[[τ²]τ]"
+
+    t12 = rootedtree([1, 2, 2, 3, 4])
+    @test order(t12) == 5
+    @test σ(t12) == 1
+    @test γ(t12) == 30
+    @test α(t12) == 4
+    @test β(t12) == α(t12)*γ(t12)
+    @test t12 == t2 ∘ t4 == t8 ∘ t1
+    @test butcher_representation(t12) == "[[[τ]]τ]"
+
+    t13 = rootedtree([1, 2, 3, 2, 3])
+    @test order(t13) == 5
+    @test σ(t13) == 2
+    @test γ(t13) == 20
+    @test α(t13) == 3
+    @test β(t13) == α(t13)*γ(t13)
+    @test t13 == t4 ∘ t2
+    @test butcher_representation(t13) == "[[τ][τ]]"
+
+    t14 = rootedtree([1, 2, 3, 3, 3])
+    @test order(t14) == 5
+    @test σ(t14) == 6
+    @test γ(t14) == 20
+    @test α(t14) == 1
+    @test β(t14) == α(t14)*γ(t14)
+    @test t14 == t1 ∘ t5
+    @test butcher_representation(t14) == "[[τ³]]"
+
+    t15 = rootedtree([1, 2, 3, 3, 4])
+    @test order(t15) == 5
+    @test σ(t15) == 1
+    @test γ(t15) == 40
+    @test α(t15) == 3
+    @test β(t15) == α(t15)*γ(t15)
+    @test t15 == t1 ∘ t6
+    @test butcher_representation(t15) == "[[[τ]τ]]"
+
+    t16 = rootedtree([1, 2, 3, 4, 4])
+    @test order(t16) == 5
+    @test σ(t16) == 2
+    @test γ(t16) == 60
+    @test α(t16) == 1
+    @test β(t16) == α(t16)*γ(t16)
+    @test t16 == t1 ∘ t7
+    @test butcher_representation(t16) == "[[[τ²]]]"
+
+    t17 = rootedtree([1, 2, 3, 4, 5])
+    @test order(t17) == 5
+    @test σ(t17) == 1
+    @test γ(t17) == 120
+    @test α(t17) == 1
+    @test β(t17) == α(t17)*γ(t17)
+    @test t17 == t1 ∘ t8
+    @test butcher_representation(t17) == "[[[[τ]]]]"
+
+    # test non-canonical representation
+    level_sequence = [1, 2, 3, 2, 3, 4, 2, 3, 2, 3, 4, 5, 6, 2, 3, 4]
+    @test σ(rootedtree(level_sequence)) == σ(RootedTrees.RootedTree(level_sequence))
+  end
+
+
+  # see butcher2008numerical, Table 302(I)
+  @testset "number of trees" begin
+    number_of_rooted_trees = [1, 1, 2, 4, 9, 20, 48, 115, 286, 719]
+    for order in 1:10
+      num = 0
+      for t in RootedTreeIterator(order)
+        num += 1
+      end
+      @test num == number_of_rooted_trees[order] == count_trees(order)
     end
   end
-end
 
-
-@testset "plots" begin
-  @testset "RootedTree" begin
-    for order in 1:4
+  # Runge-Kutta method SSPRK33 of order 3
+  @testset "Runge-Kutta order conditions" begin
+    A = [0 0 0; 1 0 0; 1/4 1/4 0]
+    b = [1/6, 1/6, 2/3]
+    c = A * fill(1, length(b))
+    for order in 1:3
       for t in RootedTreeIterator(order)
-        plot(t)
+        @test residual_order_condition(t, A, b, c) ≈ 0 atol=eps()
+      end
+    end
+    let order=4
+      res = 0.0
+      for t in RootedTreeIterator(order)
+        res += abs(residual_order_condition(t, A, b, c))
+      end
+      @test res > 10*eps()
+    end
+
+    A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
+    b = @SArray [1/6, 1/6, 2/3]
+    c = A * SVector(1, 1, 1)
+    for order in 1:3
+      @test all(RootedTreeIterator(order)) do t
+        abs(residual_order_condition(t, A, b, c)) < eps()
+      end
+    end
+
+    let order=4
+      res = 0.0
+      for t in RootedTreeIterator(order)
+        res += abs(residual_order_condition(t, A, b, c))
+      end
+      @test res > 10*eps()
+    end
+  end
+
+  # See Section 2.3 and Table 2 of
+  # - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  #   Algebraic Structures of B-series.
+  #   Foundations of Computational Mathematics
+  #   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+  @testset "partitions" begin
+    let t = rootedtree([1, 2, 3, 4, 3])
+      edge_set = [true, true, false, false]
+      reference_forest = [rootedtree([1, 2, 3]),
+                          rootedtree([4]),
+                          rootedtree([3])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 2])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 4, 3])
+      edge_set = [false, true, true, false]
+      reference_forest = [rootedtree([3]),
+                          rootedtree([2, 3, 4]),
+                          rootedtree([1])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 4, 3])
+      edge_set = [false, true, false, false]
+      reference_forest = [rootedtree([4]),
+                          rootedtree([3]),
+                          rootedtree([2, 3]),
+                          rootedtree([1])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3, 3])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 2, 2, 2])
+      edge_set = [false, false, true, true]
+      reference_forest = [rootedtree([2]),
+                          rootedtree([2]),
+                          rootedtree([1, 2, 2])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 2])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 2, 2])
+      edge_set = [false, false, false, true]
+      reference_forest = [rootedtree([3]),
+                          rootedtree([2]),
+                          rootedtree([2]),
+                          rootedtree([1, 2])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3, 2])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 2, 2])
+      edge_set = [true, true, true, true]
+      reference_forest = [rootedtree([1, 2, 3, 2, 2])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 2, 3])
+      edge_set = [true, true, false, false]
+      reference_forest = [rootedtree([3]),
+                          rootedtree([2]),
+                          rootedtree([1, 2, 3])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 2, 3])
+      edge_set = [false, true, false, false]
+      reference_forest = [rootedtree([2, 3]),
+                          rootedtree([3]),
+                          rootedtree([2]),
+                          rootedtree([1])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 2, 3])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    let t = rootedtree([1, 2, 3, 3, 3])
+      edge_set = [false, true, true, false]
+      reference_forest = [rootedtree([3]),
+                          rootedtree([2, 3, 3]),
+                          rootedtree([1])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+    # additional tests not included in the examples of the paper
+    let t = rootedtree([1, 2, 3, 2, 3])
+      edge_set = [true, false, true, true]
+      reference_forest = [rootedtree([1, 2, 3, 2]),
+                          rootedtree([3])]
+      @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+  end
+
+  # See Table 3 of
+  # - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  #   Algebraic Structures of B-series.
+  #   Foundations of Computational Mathematics
+  #   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+  @testset "all_partitions" begin
+    t = rootedtree([1, 2, 3, 3])
+    forests, skeletons = all_partitions(t)
+    for forest in forests
+      for tree in forest
+        RootedTrees.normalize_root!(tree)
+      end
+      sort!(forest)
+    end
+    sort!(forests)
+    for tree in skeletons
+      RootedTrees.normalize_root!(tree)
+    end
+    sort!(skeletons)
+
+    reference_forests = [
+      [rootedtree([1, 2, 3, 3]),],
+      [rootedtree([1]), rootedtree([1, 2, 2])],
+      [rootedtree([1]), rootedtree([1, 2, 3])],
+      [rootedtree([1]), rootedtree([1, 2, 3]),],
+      [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
+      [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
+      [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
+      [rootedtree([1]), rootedtree([1]), rootedtree([1]), rootedtree([1])],
+    ]
+    reference_skeletons = [
+      rootedtree([1]),
+      rootedtree([1, 2]),
+      rootedtree([1, 2]),
+      rootedtree([1, 2]),
+      rootedtree([1, 2, 2]),
+      rootedtree([1, 2, 3]),
+      rootedtree([1, 2, 3]),
+      rootedtree([1, 2, 3, 3]),
+    ]
+    for forest in reference_forests
+      sort!(forest)
+    end
+    sort!(reference_forests)
+    sort!(reference_skeletons)
+
+    @test forests == reference_forests
+    @test skeletons == reference_skeletons
+
+    @testset "PartitionIterator" begin
+      partitions = collect(PartitionIterator(t))
+      iterator_forests = map(first, partitions)
+      iterator_skeletons = map(last, partitions)
+      for forest in iterator_forests
+        sort!(forest)
+      end
+      sort!(iterator_forests)
+      sort!(iterator_skeletons)
+      @test iterator_forests == forests
+      @test iterator_skeletons == skeletons
+
+      for order in 1:8
+        for t in RootedTreeIterator(order)
+          forests, skeletons = all_partitions(t)
+          @test collect(zip(forests, skeletons)) == collect(PartitionIterator(t))
+        end
+      end
+
+      level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
+      level_sequence[1] -= 1
+      t = rootedtree(level_sequence)
+      @inferred PartitionIterator(t)
+      t = @inferred rootedtree!(view(level_sequence, :))
+      @inferred PartitionIterator(t)
+    end
+  end
+
+
+  # See Section 2.2 and Table 1 of
+  # - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  #   Algebraic Structures of B-series.
+  #   Foundations of Computational Mathematics
+  #   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+  @testset "splittings" begin
+    t = rootedtree([1, 2, 3, 2, 2])
+    splittings = all_splittings(t)
+    forests_and_subtrees = sort!(collect(zip(splittings.forests, splittings.subtrees)))
+
+    reference_forests_and_subtrees = sort!([
+      (empty([rootedtree([1])]),                               rootedtree([1, 2, 3, 2, 2])),
+      ([rootedtree([1])],                                      rootedtree([1, 2, 3, 2])),
+      ([rootedtree([1])],                                      rootedtree([1, 2, 3, 2])),
+      ([rootedtree([1, 2])],                                   rootedtree([1, 2, 2])),
+      ([rootedtree([1])],                                      rootedtree([1, 2, 2, 2])),
+      ([rootedtree([1, 2]), rootedtree([1])],                  rootedtree([1, 2])),
+      ([rootedtree([1, 2]), rootedtree([1])],                  rootedtree([1, 2])),
+      ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 3])),
+      ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 2])),
+      ([rootedtree([1]),    rootedtree([1])],                  rootedtree([1, 2, 2])),
+      ([rootedtree([1]),    rootedtree([1]), rootedtree([1])], rootedtree([1, 2])),
+      ([rootedtree([1, 2]), rootedtree([1]), rootedtree([1])], rootedtree([1])),
+      ([rootedtree([1, 2, 3, 2, 2])],                          rootedtree(Int[])),
+    ])
+
+    @test forests_and_subtrees == reference_forests_and_subtrees
+
+    # tested with the Python package BSeries
+    t = rootedtree([1, 2, 3, 4, 4, 2, 3, 3, 2, 3, 2, 3])
+    splittings = all_splittings(t)
+    @test length(splittings.forests) == length(splittings.subtrees) == 271
+
+    # consistency of all_splittings and the SplittingIterator
+    for order in 1:8
+      for i in RootedTreeIterator(order)
+        forests, subtrees = all_splittings(t)
+        @test collect(zip(forests, subtrees)) == collect(SplittingIterator(t))
       end
     end
   end
 
-  @testset "ColoredRootedTree" begin
-    let t = rootedtree(Int[], Int[])
-      plot(t)
-    end
-
-    let t = rootedtree([1], [1])
-      plot(t)
-    end
-
-    let t = rootedtree([1], [2])
-      plot(t)
-    end
-
-    let t = rootedtree([1], [3])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2], [1, 1])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2], [1, 2])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2], [3, 1])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2, 2], [2, 1, 1])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2, 2], [2, 1, 2])
-      plot(t)
-    end
-
-    let t = rootedtree([1, 2, 3], [3, 2, 1])
-      plot(t)
-    end
-  end
-end
+end # @testset "RootedTree"
 
 
 @testset "ColoredRootedTree" begin
@@ -719,7 +669,60 @@ end
       @test_nowarn println(devnull, t)
     end
   end
-end
+end # @testset "ColoredRootedTree"
+
+
+@testset "plots" begin
+  @testset "RootedTree" begin
+    for order in 1:4
+      for t in RootedTreeIterator(order)
+        plot(t)
+      end
+    end
+  end
+
+  @testset "ColoredRootedTree" begin
+    let t = rootedtree(Int[], Int[])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [1])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [2])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [3])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [1, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [1, 2])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [3, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 2])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 3], [3, 2, 1])
+      plot(t)
+    end
+  end
+end # @testset "plots"
 
 
 end # @testset "RootedTrees"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -854,6 +854,8 @@ end # @testset "ColoredRootedTree"
     show(IOContext(stdout, :compact=>true), ark)
     show(IOContext(stdout, :compact=>false), ark)
 
+    @test elementary_weight(rootedtree(Int[], Bool[]), ark) ≈ 1
+
     for order in 1:1
       for t in BicoloredRootedTreeIterator(order)
         @test residual_order_condition(t, ark) ≈ 0 atol=eps()
@@ -924,6 +926,23 @@ end # @testset "ColoredRootedTree"
         res += abs(residual_order_condition(t, ark))
       end
       @test res > 10*eps()
+    end
+  end
+
+  @testset "AdditiveRungeKuttaMethod, SSPRK33 three times" begin
+    # Using the same method multiple times is equivalent to using a plain RK
+    # method without any splitting/partitioning/decomposition
+    A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
+    b = @SArray [1/6, 1/6, 2/3]
+    rk = RungeKuttaMethod(A, b)
+    ark = AdditiveRungeKuttaMethod([rk, rk, rk])
+
+    let t = rootedtree([1, 2, 2], [1, 2, 3])
+      @test residual_order_condition(t, ark) ≈ 0 atol=eps()
+    end
+
+    let t = rootedtree([1, 2, 3, 2], [1, 2, 3, 1])
+      @test abs(residual_order_condition(t, ark)) > 10*eps()
     end
   end
 end # @testset "Order conditions"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,4 +591,81 @@ end
 end
 
 
+@testset "ColoredRootedTree" begin
+  @testset "functions on trees" begin
+    # See Araujo, Murua, and Sanz-Serna (1997), Table 1
+    # https://doi.org/10.1137/S0036142995292128
+    let t = rootedtree(Int[], Int[])
+      @test order(t) == 0
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 1
+    end
+
+    let t = rootedtree([1], [1])
+      @test order(t) == 1
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 1
+    end
+
+    let t = rootedtree([1], [2])
+      @test order(t) == 1
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 1
+    end
+
+    let t = rootedtree([1], [3])
+      @test order(t) == 1
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 1
+    end
+
+    let t = rootedtree([1, 2], [1, 1])
+      @test order(t) == 2
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 2
+    end
+
+    let t = rootedtree([1, 2], [1, 2])
+      @test order(t) == 2
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 2
+    end
+
+    let t = rootedtree([1, 2], [3, 1])
+      @test order(t) == 2
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 2
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 1])
+      @test order(t) == 3
+      @test α(t) == 1
+      @test σ(t) == 2
+      @test γ(t) == 3
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 2])
+      @test order(t) == 3
+      @test α(t) == 2
+      @test σ(t) == 1
+      @test γ(t) == 3
+    end
+
+    let t = rootedtree([1, 2, 3], [3, 2, 1])
+      @test order(t) == 3
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 6
+    end
+  end
+end
+
+
 end # @testset "RootedTrees"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -583,8 +583,52 @@ end
 
 
 @testset "plots" begin
-  for order in 1:4
-    for t in RootedTreeIterator(order)
+  @testset "RootedTree" begin
+    for order in 1:4
+      for t in RootedTreeIterator(order)
+        plot(t)
+      end
+    end
+  end
+
+  @testset "ColoredRootedTree" begin
+    let t = rootedtree(Int[], Int[])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [1])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [2])
+      plot(t)
+    end
+
+    let t = rootedtree([1], [3])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [1, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [1, 2])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2], [3, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 1])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 2], [2, 1, 2])
+      plot(t)
+    end
+
+    let t = rootedtree([1, 2, 3], [3, 2, 1])
       plot(t)
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -670,24 +670,23 @@ end # @testset "RootedTree"
     end
 
     # more tests of the canonical representation
-    t = rootedtree([1, 2, 3, 2, 3, 3, 2])
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2], Bool[1, 0, 1, 1, 0, 0, 0])
     @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2]
     @test !isempty(t)
 
-    t = rootedtree([1, 2, 3, 2, 3, 4, 2, 3])
+    t = rootedtree([1, 2, 3, 2, 3, 4, 2, 3], [1, 0, 1, 1, 0, 0, 0, 1])
     @test t.level_sequence == [1, 2, 3, 4, 2, 3, 2, 3]
     @test !isempty(t)
 
-    t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3])
+    t = rootedtree([1, 2, 3, 2, 3, 3, 2, 3], Bool[1, 0, 1, 1, 0, 0, 0, 1])
     @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2, 3]
     @test !isempty(t)
 
     @test isempty(rootedtree(Int[]))
     @test isempty(empty(t))
 
-    level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
-    level_sequence[1] -= 1
-    @inferred rootedtree(level_sequence)
+    # misc
+    @test_throws DimensionMismatch rootedtree([1, 2, 3], [1, 2])
   end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,7 @@ Plots.unicodeplots()
     @test RootedTrees.latexify(t1) == latex_string
     @test latexify(t1) == latex_string
     @test isempty(RootedTrees.subtrees(t1))
+    @test butcher_representation(empty(t1)) == "∅"
     @test RootedTrees.latexify(empty(t1)) == "\\varnothing"
 
     @inferred order(t1)
@@ -699,6 +700,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 1
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "∅"
     end
 
     let t = rootedtree([1], [1])
@@ -707,6 +709,9 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 1
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "τ₁"
+
+      @test t ∘ t == rootedtree([1, 2], [1, 1])
     end
 
     let t = rootedtree([1], [2])
@@ -715,6 +720,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 1
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "τ₂"
     end
 
     let t = rootedtree([1], [3])
@@ -723,6 +729,16 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 1
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "τ₃"
+    end
+
+    let t = rootedtree([1], [typemax(Int)])
+      @test order(t) == 1
+      @test α(t) == 1
+      @test σ(t) == 1
+      @test γ(t) == 1
+      @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "τ₀"
     end
 
     let t = rootedtree([1, 2], [1, 1])
@@ -731,6 +747,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 2
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[τ₁]₁"
     end
 
     let t = rootedtree([1, 2], [1, 2])
@@ -739,6 +756,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 2
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[τ₂]₁"
     end
 
     let t = rootedtree([1, 2], [3, 1])
@@ -747,6 +765,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 2
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[τ₁]₃"
     end
 
     let t = rootedtree([1, 2, 2], [2, 1, 1])
@@ -755,6 +774,7 @@ end # @testset "RootedTree"
       @test σ(t) == 2
       @test γ(t) == 3
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[τ₁²]₂"
     end
 
     let t = rootedtree([1, 2, 2], [2, 1, 2])
@@ -763,6 +783,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 3
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[τ₁τ₂]₂"
     end
 
     let t = rootedtree([1, 2, 3], [3, 2, 1])
@@ -771,6 +792,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 6
       @test_nowarn println(devnull, t)
+      @test butcher_representation(t) == "[[τ₁]₂]₃"
     end
   end
 end # @testset "ColoredRootedTree"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -644,6 +644,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 1
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1], [1])
@@ -651,6 +652,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 1
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1], [2])
@@ -658,6 +660,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 1
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1], [3])
@@ -665,6 +668,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 1
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2], [1, 1])
@@ -672,6 +676,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 2
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2], [1, 2])
@@ -679,6 +684,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 2
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2], [3, 1])
@@ -686,6 +692,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 2
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2, 2], [2, 1, 1])
@@ -693,6 +700,7 @@ end
       @test α(t) == 1
       @test σ(t) == 2
       @test γ(t) == 3
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2, 2], [2, 1, 2])
@@ -700,6 +708,7 @@ end
       @test α(t) == 2
       @test σ(t) == 1
       @test γ(t) == 3
+      @test_nowarn println(devnull, t)
     end
 
     let t = rootedtree([1, 2, 3], [3, 2, 1])
@@ -707,6 +716,7 @@ end
       @test α(t) == 1
       @test σ(t) == 1
       @test γ(t) == 6
+      @test_nowarn println(devnull, t)
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -691,6 +691,22 @@ end # @testset "RootedTree"
   end
 
 
+  @testset "hashing" begin
+    hashes = [hash(rootedtree(Int[], Bool[]))]
+    for o in 1:8
+      for t in BicoloredRootedTreeIterator(o)
+        new_hash = @inferred hash(t)
+        @test !(new_hash in hashes)
+        push!(hashes, new_hash)
+      end
+    end
+    t = rootedtree([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 2],
+                   Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+    new_hash = @inferred hash(t)
+    @test !(new_hash in hashes)
+  end
+
+
   @testset "functions on trees" begin
     # See Araujo, Murua, and Sanz-Serna (1997), Table 1
     # https://doi.org/10.1137/S0036142995292128
@@ -793,6 +809,19 @@ end # @testset "RootedTree"
       @test γ(t) == 6
       @test_nowarn println(devnull, t)
       @test butcher_representation(t) == "[[τ₁]₂]₃"
+    end
+  end
+
+  # see butcher2008numerical, Table 302(I)
+  @testset "number of trees" begin
+    number_of_rooted_trees = [1, 1, 2, 4, 9, 20, 48, 115, 286, 719]
+    for order in 1:10
+      num = 0
+      for t in BicoloredRootedTreeIterator(order)
+        num += 1
+      end
+      # number of plain rooted trees times number of possible color sequences
+      @test num == number_of_rooted_trees[order] * 2^order
     end
   end
 end # @testset "ColoredRootedTree"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -931,7 +931,7 @@ end # @testset "ColoredRootedTree"
 
   @testset "AdditiveRungeKuttaMethod, Griep3" begin
     # Oswald Knoth and J. Wensch (2014)
-    # "Generalized Split-Explicit Runge–Kutta Methods for the
+    # "Generalized Split-Explicit Runge-Kutta Methods for the
     # Compressible Euler Equations".
     # Monthly Weather Review, 142, 2067-2081
     A_explicit = @SArray [0 0 0; 1//2 0 0; -1 2 0]


### PR DESCRIPTION
This is a first step towards colored rooted trees. This PR implements a struct `ColoredRootedTree` which can represent a rooted tree with an arbitrary number of colors. It also contains some standard functions on these trees including (lexicographical) comparisons, `order`, `symmetry` (or `σ`), `density` (or `γ`), and `α` (number of labelings).

- [x] We should also get `butcher_representation`
- [x] Plotting with colors
- [x] `BicoloredRootedTreeIterator` 
- [ ] General `ColoredRootedTreeIterator`?
- [ ] filter function to filter out some trees for the iterators, e.g., for Nyström methods
- [x] equivalents of `elementary_weight`, `derivative_weight`, and `residual_order_condition`
- [ ] Possible performance improvements are marked with `# TODO: ColoredRootedTree`

Xref #28