### PR TITLE
introduce RungeKuttaMethod

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootedTrees"
 uuid = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "2.6.8-pre"
+version = "2.7.0"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,7 @@ end
   A = [0 0 0; 1 0 0; 1/4 1/4 0]
   b = [1/6, 1/6, 2/3]
   rk = RungeKuttaMethod(A, b)
+  show(IOContext(stdout, :compact=>false), rk)
   for order in 1:3
     for t in RootedTreeIterator(order)
       @test residual_order_condition(t, rk) ≈ 0 atol=eps()
@@ -318,6 +319,7 @@ end
   A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
   b = @SArray [1/6, 1/6, 2/3]
   rk = RungeKuttaMethod(A, b)
+  show(IOContext(stdout, :compact=>true), rk)
   for order in 1:3
     @test all(RootedTreeIterator(order)) do t
       abs(residual_order_condition(t, rk)) < eps()
@@ -330,6 +332,15 @@ end
       res += abs(residual_order_condition(t, rk))
     end
     @test res > 10*eps()
+  end
+
+  # deprecations
+  let order=4
+    for t in RootedTreeIterator(order)
+      @test elementary_weight(t, rk.A, rk.b, rk.c) ≈ elementary_weight(t, rk)
+      @test derivative_weight(t, rk.A, rk.b, rk.c) ≈ derivative_weight(t, rk)
+      @test residual_order_condition(t, rk.A, rk.b, rk.c) ≈ residual_order_condition(t, rk)
+    end
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -301,33 +301,33 @@ end
 @testset "Runge-Kutta order conditions" begin
   A = [0 0 0; 1 0 0; 1/4 1/4 0]
   b = [1/6, 1/6, 2/3]
-  c = A * fill(1, length(b))
+  rk = RungeKuttaMethod(A, b)
   for order in 1:3
     for t in RootedTreeIterator(order)
-      @test residual_order_condition(t, A, b, c) ≈ 0 atol=eps()
+      @test residual_order_condition(t, rk) ≈ 0 atol=eps()
     end
   end
   let order=4
     res = 0.0
     for t in RootedTreeIterator(order)
-      res += abs(residual_order_condition(t, A, b, c))
+      res += abs(residual_order_condition(t, rk))
     end
     @test res > 10*eps()
   end
 
   A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
   b = @SArray [1/6, 1/6, 2/3]
-  c = A * SVector(1, 1, 1)
+  rk = RungeKuttaMethod(A, b)
   for order in 1:3
     @test all(RootedTreeIterator(order)) do t
-      abs(residual_order_condition(t, A, b, c)) < eps()
+      abs(residual_order_condition(t, rk)) < eps()
     end
   end
 
   let order=4
     res = 0.0
     for t in RootedTreeIterator(order)
-      res += abs(residual_order_condition(t, A, b, c))
+      res += abs(residual_order_condition(t, rk))
     end
     @test res > 10*eps()
   end


### PR DESCRIPTION
This allows us to dispatch on the type of the time integration scheme later, e.g., when including additive or partitioned RK methods.