### PR TITLE
docs

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,32 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    # Do not run on forks to avoid authorization errors
+    # Source: https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18
+    if: github.repository_owner == 'SciML'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Delete preview and history
+        shell: bash
+        run: |
+            git config user.name "Documenter.jl"
+            git config user.email "documenter@juliadocs.github.io"
+            git rm -rf --ignore-unmatch "previews/PR$PRNUM"
+            git commit -m "delete preview" --allow-empty
+            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+        env:
+            PRNUM: ${{ github.event.number }}
+
+      - name: Push changes
+        run: |
+            git push --force origin gh-pages-new:gh-pages

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+    paths-ignore:
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'utils/**'
+  pull_request:
+    paths-ignore:
+      - '.zenodo.json'
+      - '.github/workflows/benchmark.yml'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/TagBot.yml'
+      - 'benchmark/**'
+      - 'utils/**'
+  workflow_dispatch:
+
+# Cancel redundant CI tests automatically
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.6'
+          show-versioninfo: true
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+        env:
+          PYTHON: ""
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        env:
+          PYTHON: ""
+      - name: Build and deploy documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
+          PYTHON: ""
+        run: julia --project=docs --color=yes docs/make.jl

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,20 @@
+@online{ketcheson2021computing,
+  title={Computing with {B}-series},
+  author={Ketcheson, David I and Ranocha, Hendrik},
+  year={2021},
+  month={11},
+  eprint={2111.11680},
+  eprinttype={arXiv},
+  eprintclass={math.NA}
+}
+
+@misc{ranocha2019rootedtrees,
+  title={{RootedTrees.jl}: {A} collection of functionality around rooted trees
+         to generate order conditions for {R}unge-{K}utta methods in {J}ulia
+         for differential equations and scientific machine learning ({SciM}L)},
+  author={Ranocha, Hendrik and contributors},
+  year={2019},
+  month={05},
+  howpublished={\url{https://github.com/SciML/RootedTrees.jl}},
+  doi={10.5281/zenodo.5534590}
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+RootedTrees.jl is an open-source project and we are very happy
+to accept contributions from the community. Please feel free to open issues
+or submit patches (preferably as pull requests) any time. For planned larger
+contributions, it is often beneficial to get in contact first, for example via
+issues.
+
+RootedTrees.jl and its contributions are licensed under the
+MIT license (see [LICENSE.md](LICENSE.md)). As a contributor, you certify
+that all your contributions are in conformance with the *Developer Certificate
+of Origin (Version 1.1)*, which is reproduced below.
+
+## Developer Certificate of Origin (Version 1.1)
+The following text was taken from
+[https://developercertificate.org](https://developercertificate.org):
+
+    Developer Certificate of Origin
+    Version 1.1
+
+    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+    1 Letterman Drive
+    Suite D4700
+    San Francisco, CA, 94129
+
+    Everyone is permitted to copy and distribute verbatim copies of this
+    license document, but changing it is not allowed.
+
+
+    Developer's Certificate of Origin 1.1
+
+    By making a contribution to this project, I certify that:
+
+    (a) The contribution was created in whole or in part by me and I
+        have the right to submit it under the open source license
+        indicated in the file; or
+
+    (b) The contribution is based upon previous work that, to the best
+        of my knowledge, is covered under an appropriate open source
+        license and I have the right under that license to submit that
+        work with modifications, whether created in whole or in part
+        by me, under the same open source license (unless I am
+        permitted to submit under a different license), as indicated
+        in the file; or
+
+    (c) The contribution was provided directly to me by some other
+        person who certified (a), (b) or (c) and I have not modified
+        it.
+
+    (d) I understand and agree that this project and the contribution
+        are public and that a record of the contribution (including all
+        personal information I submit with it, including my sign-off) is
+        maintained indefinitely and may be redistributed consistent with
+        this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,19 @@ Additionally, functions on trees connected to Runge-Kutta methods are implemente
 
 If you use
 [RootedTrees.jl](https://github.com/SciML/RootedTrees.jl)
-for your research, please cite it using the bibtex entry
+for your research, please cite the paper
+```bibtex
+@online{ketcheson2021computing,
+  title={Computing with {B}-series},
+  author={Ketcheson, David I and Ranocha, Hendrik},
+  year={2021},
+  month={11},
+  eprint={2111.11680},
+  eprinttype={arXiv},
+  eprintclass={math.NA}
+}
+```
+In addition, you can also refer to RootedTrees.jl directly as
 ```bibtex
 @misc{ranocha2019rootedtrees,
   title={{RootedTrees.jl}: {A} collection of functionality around rooted trees

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RootedTrees
 
+[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://SciML.github.io/RootedTrees.jl/stable)
+[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://SciML.github.io/RootedTrees.jl/dev)
 [![Build Status](https://github.com/SciML/RootedTrees.jl/workflows/CI/badge.svg)](https://github.com/SciML/RootedTrees.jl/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/SciML/RootedTrees.jl/badge.svg?branch=main)](https://coveralls.io/github/SciML/RootedTrees.jl?branch=main)
 [![codecov](https://codecov.io/gh/SciML/RootedTrees.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/SciML/RootedTrees.jl)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,71 @@
+using Documenter
+import Pkg
+using RootedTrees
+
+# Define module-wide setups such that the respective modules are available in doctests
+DocMeta.setdocmeta!(RootedTrees,
+  :DocTestSetup, :(using RootedTrees); recursive=true)
+
+# Copy some files from the top level directory to the docs and modify them
+# as necessary
+open(joinpath(@__DIR__, "src", "license.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/LICENSE.md"
+  ```
+  """)
+  # Write the modified contents
+  println(io, "# License")
+  println(io, "")
+  for line in eachline(joinpath(dirname(@__DIR__), "LICENSE.md"))
+    line = replace(line, "[LICENSE.md](LICENSE.md)" => "[License](@ref)")
+    println(io, "> ", line)
+  end
+end
+
+open(joinpath(@__DIR__, "src", "contributing.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/CONTRIBUTING.md"
+  ```
+  """)
+  # Write the modified contents
+  println(io, "# Contributing")
+  println(io, "")
+  for line in eachline(joinpath(dirname(@__DIR__), "CONTRIBUTING.md"))
+    line = replace(line, "[LICENSE.md](LICENSE.md)" => "[License](@ref)")
+    println(io, "> ", line)
+  end
+end
+
+# Make documentation
+makedocs(
+  modules = [RootedTrees],
+  sitename="RootedTrees.jl",
+  format = Documenter.HTML(
+    prettyurls = get(ENV, "CI", nothing) == "true",
+    canonical = "https://SciML.github.io/RootedTrees.jl/stable",
+    ansicolor = true
+  ),
+  # Explicitly specify documentation structure
+  pages = [
+    "Home" => "index.md",
+    # "Introduction" => "introduction.md",
+    # "Tutorials" => [
+    #   "tutorials/modified_equations.md",
+    # ],
+    # "Benchmarks" => "benchmarks.md",
+    "API reference" => "api_reference.md",
+    "Contributing" => "contributing.md",
+    "License" => "license.md"
+  ],
+  strict = true # to make the GitHub action fail when doctests fail
+)
+
+deploydocs(
+  repo = "github.com/SciML/RootedTrees.jl",
+  devbranch = "main",
+  push_preview = true
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -52,7 +52,7 @@ makedocs(
   # Explicitly specify documentation structure
   pages = [
     "Home" => "index.md",
-    # "Introduction" => "introduction.md",
+    "Introduction" => "introduction.md",
     # "Tutorials" => [
     #   "tutorials/modified_equations.md",
     # ],

--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -1,0 +1,10 @@
+# RootedTrees.jl API
+
+```@meta
+CurrentModule = RootedTrees
+```
+
+```@autodocs
+Modules = [RootedTrees]
+```
+

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,68 @@
+# RootedTrees.jl
+
+The [Julia](https://julialang.org/) package
+[RootedTrees.jl](https://github.com/SciML/RootedTrees.jl)
+provides a collection of functionality around rooted trees, including
+the generation of order conditions for Runge-Kutta methods.
+This package also provides basic functionality for
+[BSeries.jl](https://github.com/ranocha/BSeries.jl).
+
+
+## Installation
+
+[RootedTrees.jl](https://github.com/SciML/RootedTrees.jl)
+is a registered Julia package. Thus, you can install it from the Julia REPL via
+```julia
+julia> using Pkg; Pkg.add("RootedTrees")
+```
+
+If you want to update RootedTrees.jl, you can use
+```julia
+julia> using Pkg; Pkg.update("RootedTrees")
+```
+As usual, if you want to update RootedTrees.jl and all other
+packages in your current project, you can execute
+```julia
+julia> using Pkg; Pkg.update()
+```
+
+
+## Referencing
+
+If you use
+[RootedTrees.jl](https://github.com/SciML/RootedTrees.jl)
+for your research, please cite the paper
+```bibtex
+@online{ketcheson2021computing,
+  title={Computing with {B}-series},
+  author={Ketcheson, David I and Ranocha, Hendrik},
+  year={2021},
+  month={11},
+  eprint={2111.11680},
+  eprinttype={arXiv},
+  eprintclass={math.NA}
+}
+```
+In addition, you can also refer to RootedTrees.jl directly as
+```bibtex
+@misc{ranocha2019rootedtrees,
+  title={{RootedTrees.jl}: {A} collection of functionality around rooted trees
+         to generate order conditions for {R}unge-{K}utta methods in {J}ulia
+         for differential equations and scientific machine learning ({SciM}L)},
+  author={Ranocha, Hendrik and contributors},
+  year={2019},
+  month={05},
+  howpublished={\url{https://github.com/SciML/RootedTrees.jl}},
+  doi={10.5281/zenodo.5534590}
+}
+```
+Please also cite the appropriate references for specific functions you use,
+which can be obtained from their docstrings.
+
+
+## License and contributing
+
+This project is licensed under the MIT license (see [License](@ref)).
+Since it is an open-source project, we are very happy to accept contributions
+from the community. Please refer to the section [Contributing](@ref) for more
+details.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -6,19 +6,19 @@ are
 - John Charles Butcher.
   "Numerical methods for ordinary differential equations".
   John Wiley & Sons, 2016.
-  https://doi.org/10.1002/9780470753767
+  [DOI: 10.1002/9780470753767](https://doi.org/10.1002/9780470753767)
 - Ernst Hairer, Gerhard Wanner, Syvert P. Nørsett.
   "Solving Ordinary Differential Equations I".
   Springer, 1993.
-  https://doi.org/10.1007/978-3-540-78862-1
+  [DOI: 10.1007/978-3-540-78862-1](https://doi.org/10.1007/978-3-540-78862-1)
 - Ernst Hairer, Gerhard Wanner.
   "Solving Ordinary Differential Equations II".
   Springer, 1996.
-  https://doi.org/10.1007/978-3-642-05221-7
+  [DOI: 10.1007/978-3-642-05221-7](https://doi.org/10.1007/978-3-642-05221-7)
 - Ernst Hairer, Gerhard Wanner, Christian Lubich.
   "Geometric Numerical Integration".
   Springer, 2006.
-  https://doi.org/10.1007/3-540-30666-8
+  [DOI: 10.1007/3-540-30666-8](https://doi.org/10.1007/3-540-30666-8)
 
 
 ## Construction

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,28 +1,29 @@
-# RootedTrees
+# Introduction
 
-[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://SciML.github.io/RootedTrees.jl/stable)
-[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://SciML.github.io/RootedTrees.jl/dev)
-[![Build Status](https://github.com/SciML/RootedTrees.jl/workflows/CI/badge.svg)](https://github.com/SciML/RootedTrees.jl/actions?query=workflow%3ACI)
-[![Coverage Status](https://coveralls.io/repos/github/SciML/RootedTrees.jl/badge.svg?branch=main)](https://coveralls.io/github/SciML/RootedTrees.jl?branch=main)
-[![codecov](https://codecov.io/gh/SciML/RootedTrees.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/SciML/RootedTrees.jl)
-[![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5534590.svg)](https://doi.org/10.5281/zenodo.5534590)
+[`RootedTree`](@ref)s are useful to analyze properties of time integration
+methods such as Runge-Kutta methods. Some common references introducing them
+are
+- John Charles Butcher.
+  "Numerical methods for ordinary differential equations".
+  John Wiley & Sons, 2016.
+  https://doi.org/10.1002/9780470753767
+- Ernst Hairer, Gerhard Wanner, Syvert P. Nørsett.
+  "Solving Ordinary Differential Equations I".
+  Springer, 1993.
+  https://doi.org/10.1007/978-3-540-78862-1
+- Ernst Hairer, Gerhard Wanner.
+  "Solving Ordinary Differential Equations II".
+  Springer, 1996.
+  https://doi.org/10.1007/978-3-642-05221-7
+- Ernst Hairer, Gerhard Wanner, Christian Lubich.
+  "Geometric Numerical Integration".
+  Springer, 2006.
+  https://doi.org/10.1007/3-540-30666-8
 
-A collection of functionality around rooted trees to generate order conditions
-for Runge-Kutta methods in [Julia](https://julialang.org/).
-This package also provides basic functionality for
-[BSeries.jl](https://github.com/ranocha/BSeries.jl).
 
+## Construction
 
-## API Documentation
-
-The API of RootedTrees.jl is documented in the following. Additional information
-on each function is available in their docstrings and in the
-[online documentation](https://SciML.github.io/RootedTrees.jl/stable).
-
-### Construction
-
-`RootedTree`s are represented using level sequences, i.e., `AbstractVector`s
+[`RootedTree`](@ref)s are represented using level sequences, i.e., `AbstractVector`s
 containing the distances of the nodes from the root, see
 
 - Beyer, Terry, and Sandra Mitchell Hedetniemi.
@@ -30,17 +31,17 @@ containing the distances of the nodes from the root, see
   SIAM Journal on Computing 9.4 (1980): 706-712.
   [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
 
-`RootedTree`s can be constructed from their level sequence using
+[`RootedTree`](@ref)s can be constructed from their level sequence using
 ```julia
 julia> t = rootedtree([1, 2, 3, 2])
 RootedTree{Int64}: [1, 2, 3, 2]
 ```
 In the notation of [Butcher (Numerical Methods for ODEs, 2016)](https://doi.org/10.1002/9781119121534),
 this tree can be written as `[[τ] τ]` or `(τ ∘ τ) ∘ (τ ∘ τ)`, where
-`∘` is the non-associative Butcher product of `RootedTree`s, which is also
+`∘` is the non-associative Butcher product of [`RootedTree`](@ref)s, which is also
 implemented.
 
-To get the representation of a `RootedTree` introduced by Butcher, use `butcher_representation`:
+To get the representation of a [`RootedTree`](@ref) introduced by Butcher, use `butcher_representation`:
 ```julia
 julia> t = rootedtree([1, 2, 3, 4, 3, 3, 2, 2, 2, 2, 2])
 RootedTree{Int64}: [1, 2, 3, 4, 3, 3, 2, 2, 2, 2, 2]
@@ -60,10 +61,11 @@ in the preamble can be obtained from the docstring of `RootedTrees.latexify`
 used when you are `using Latexify` and their function `latexify`, see
 [Latexify.jl](https://github.com/korsbo/Latexify.jl).
 
-### Iteration over `RootedTree`s
+
+## Iteration over [`RootedTree`](@ref)s
 
 A `RootedTreeIterator(order::Integer)` can be used to iterate efficiently
-over all `RootedTree`s of a given `order`.
+over all [`RootedTree`](@ref)s of a given `order`.
 
 Be careful that the iterator is stateful for efficiency reasons, so you might
 need to use `copy` appropriately, e.g.,
@@ -83,11 +85,12 @@ julia> map(copy, RootedTreeIterator(4))
  RootedTree{Int64}: [1, 2, 2, 2]
 ```
 
-### Functions on Trees
 
-The usual functions on `RootedTree`s are implemented, cf.
+## Functions on Trees
+
+The usual functions on [`RootedTree`](@ref)s are implemented, cf.
 [Butcher (Numerical Methods for ODEs, 2016)](https://doi.org/10.1002/9781119121534).
-- `order(t::RootedTree)`: The order of a `RootedTree`, i.e., the length of its level sequence.
+- `order(t::RootedTree)`: The order of a [`RootedTree`](@ref), i.e., the length of its level sequence.
 - `σ(t::RootedTree)` or `symmetry(t)`: The symmetry `σ` of a rooted tree, i.e., the order of the group of automorphisms on a particular labelling (of the vertices) of `t`.
 - `γ(t::RootedTree)` or `density(t)`: The density `γ(t)` of a rooted tree, i.e., the product over all vertices of `t` of the order of the subtree rooted at that vertex.
 - `α(t::RootedTree)`: The number of monotonic labelings of `t` not equivalent under the symmetry group.
@@ -99,39 +102,3 @@ Additionally, functions on trees connected to Runge-Kutta methods are implemente
 - `residual_order_condition(t, A, b, c)`: The residual of the order condition
   `(Φ(t) - 1/γ(t)) / σ(t)` with elementary weight `Φ(t)`, density `γ(t)`, and symmetry `σ(t)` of the rooted tree `t` for the Runge-Kutta method with Butcher coefficients `A, b, c`.
 
-
-## Brief Changelog
-
-- v2.0: Rooted trees are considered up to isomorphisms introduced by shifting
-  each coefficient of their level sequence by the same number.
-
-
-## Referencing
-
-If you use
-[RootedTrees.jl](https://github.com/SciML/RootedTrees.jl)
-for your research, please cite the paper
-```bibtex
-@online{ketcheson2021computing,
-  title={Computing with {B}-series},
-  author={Ketcheson, David I and Ranocha, Hendrik},
-  year={2021},
-  month={11},
-  eprint={2111.11680},
-  eprinttype={arXiv},
-  eprintclass={math.NA}
-}
-```
-In addition, you can also refer to RootedTrees.jl directly as
-```bibtex
-@misc{ranocha2019rootedtrees,
-  title={{RootedTrees.jl}: {A} collection of functionality around rooted trees
-         to generate order conditions for {R}unge-{K}utta methods in {J}ulia
-         for differential equations and scientific machine learning ({SciM}L)},
-  author={Ranocha, Hendrik and contributors},
-  year={2019},
-  month={05},
-  howpublished={\url{https://github.com/SciML/RootedTrees.jl}},
-  doi={10.5281/zenodo.5534590}
-}
-```


### PR DESCRIPTION
The functionality of RootedTrees.jl is growing. Thus, documenting everything in the README.md alone isn't enough anymore. This PR sets up a first simple version of the API docs.

The preview is available at https://sciml.github.io/RootedTrees.jl/previews/PR60/

# TODO

- [x] Add Documenter to the required checks