### PR TITLE
partitions of colored trees

### DIFF
--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -885,8 +885,11 @@ end
 
 # Allocate global buffer for `PartitionIterator` for each thread
 const PARTITION_ITERATOR_BUFFER_FOREST_T = Vector{Vector{Int}}()
+const PARTITION_ITERATOR_BUFFER_FOREST_T_COLORS = Vector{Vector{Bool}}()
 const PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE = Vector{Vector{Int}}()
+const PARTITION_ITERATOR_BUFFER_FOREST_COLOR_SEQUENCE = Vector{Vector{Bool}}()
 const PARTITION_ITERATOR_BUFFER_SKELETON = Vector{Vector{Int}}()
+const PARTITION_ITERATOR_BUFFER_SKELETON_COLORS = Vector{Vector{Bool}}()
 const PARTITION_ITERATOR_BUFFER_EDGE_SET = Vector{Vector{Bool}}()
 const PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP = Vector{Vector{Bool}}()
 
@@ -1350,10 +1353,16 @@ function __init__()
   # PartitionIterator
   Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T,
                            Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T_COLORS,
+                           Vector{Int}(undef, BUFFER_LENGTH))
   Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE,
                            Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_COLOR_SEQUENCE,
+                           Vector{Bool}(undef, BUFFER_LENGTH))
   Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON,
                            Vector{Int}(undef, BUFFER_LENGTH))
+  Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON_COLORS,
+                           Vector{Bool}(undef, BUFFER_LENGTH))
   Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET,
                            Vector{Bool}(undef, BUFFER_LENGTH))
   Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -526,7 +526,6 @@ end
 
 
 # partitions
-# TODO: partitions; add documentation in the README to make them public API
 """
     partition_forest(t::RootedTree, edge_set)
 
@@ -674,7 +673,6 @@ function Base.collect(forest::PartitionForestIterator)
 end
 
 
-# TODO: partitions; add documentation in the README to make them public API
 """
     partition_skeleton(t::RootedTree, edge_set)
 
@@ -737,7 +735,6 @@ function partition_skeleton!(level_sequence, edge_set)
 end
 
 
-# TODO: partitions; add documentation in the README to make them public API
 """
     all_partitions(t::RootedTree)
 
@@ -918,7 +915,6 @@ end
 
 
 # splittings
-# TODO: splittings; add documentation in the README to make them public API
 """
     all_splittings(t::RootedTree)
 

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -676,9 +676,9 @@ end
 """
     partition_skeleton(t::RootedTree, edge_set)
 
-Form the partition skeleton of the rooted tree `t`, i.e., the rooted tree obtained
-by contracting each tree of the partition forest to a single vertex and re-establishing
-the edges removed to obtain the partition forest.
+Form the partition skeleton of the rooted tree `t`, i.e., the rooted tree
+obtained by contracting each tree of the partition forest to a single vertex
+and re-establishing the edges removed to obtain the partition forest.
 
 See also [`partition_forest`](@ref) and [`PartitionIterator`](@ref).
 

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -296,6 +296,20 @@ function subtrees(t::ColoredRootedTree)
 end
 
 
+
+# TODO: ColoredRootedTree. partitions
+# partition_skeleton!
+# PartitionForestIterator
+# PartitionIterator
+
+
+
+# TODO: ColoredRootedTree. splittings
+# SplittingIterator
+
+
+
+
 # additional representation and construction methods
 
 function Base.:∘(t1::ColoredRootedTree, t2::ColoredRootedTree)

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -85,10 +85,32 @@ Base.copy(t::ColoredRootedTree) = ColoredRootedTree(copy(t.level_sequence), copy
 Base.isempty(t::ColoredRootedTree) = isempty(t.level_sequence)
 Base.empty(t::ColoredRootedTree) = ColoredRootedTree(empty(t.level_sequence), empty(t.color_sequence), iscanonical(t))
 
+@inline function Base.copy!(t_dst::ColoredRootedTree, t_src::ColoredRootedTree)
+  copy!(t_dst.level_sequence, t_src.level_sequence)
+  copy!(t_dst.color_sequence, t_src.color_sequence)
+  return t_dst
+end
+
+# Internal interface
 @inline function unsafe_deleteat!(t::ColoredRootedTree, i)
   deleteat!(t.level_sequence, i)
   deleteat!(t.color_sequence, i)
   return t
+end
+
+# Internal interface
+@inline function unsafe_resize!(t::ColoredRootedTree, n::Integer)
+  resize!(t.level_sequence, n)
+  resize!(t.color_sequence, n)
+  return t
+end
+
+# Internal interface
+@inline function unsafe_copyto!(t_dst::ColoredRootedTree, dst_offset,
+                                t_src::ColoredRootedTree, src_offset, N)
+  copyto!(t_dst.level_sequence, dst_offset, t_src.level_sequence, src_offset, N)
+  copyto!(t_dst.color_sequence, dst_offset, t_src.color_sequence, src_offset, N)
+  return t_dst
 end
 
 

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -298,7 +298,74 @@ end
 
 
 # TODO: ColoredRootedTree. partitions
-# partition_skeleton!
+"""
+    partition_skeleton(t::ColoredRootedTree, edge_set)
+
+Form the partition skeleton of the colored rooted tree `t`, i.e., the
+colored rooted tree obtained by contracting each tree of the partition forest
+to a single vertex and re-establishing the edges removed to obtain the
+partition forest.
+
+See also [`PartitionIterator`](@ref).
+
+# References
+
+Sections 2.3 and 6.1 of
+- Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  Algebraic Structures of B-series.
+  Foundations of Computational Mathematics
+  [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+"""
+function partition_skeleton(t::ColoredRootedTree, edge_set)
+  @boundscheck begin
+    @assert order(t) == length(edge_set) + 1
+  end
+
+  edge_set_copy = copy(edge_set)
+  skeleton = ColoredRootedTree(
+    copy(t.level_sequence), copy(t.color_sequence), true)
+  return partition_skeleton!(skeleton, edge_set_copy)
+end
+
+# internal in-place version of partition_skeleton modifying the inputs
+function partition_skeleton!(skeleton::ColoredRootedTree, edge_set)
+  level_sequence = skeleton.level_sequence
+  color_sequence = skeleton.color_sequence
+
+  # Iterate over all edges that shall be kept/contracted.
+  # We start the iteration at the end since this will result in less memory
+  # moves because we have already reduced the size of the vectors when reaching
+  # the beginning.
+  edge_to_contract = findlast(edge_set)
+  while edge_to_contract !== nothing
+    # Contract the corresponding edge by removing the subtree root and promoting
+    # the rest of the subtree.
+    # Remember the convention node = edge + 1
+    subtree_root_index = edge_to_contract + 1
+    subtree_last_index = subtree_root_index + 1
+    while subtree_last_index <= length(level_sequence)
+      if level_sequence[subtree_last_index] > level_sequence[subtree_root_index]
+        level_sequence[subtree_last_index] -= 1
+        subtree_last_index += 1
+      else
+        break
+      end
+    end
+
+    # Remove the root node
+    deleteat!(level_sequence, subtree_root_index)
+    deleteat!(color_sequence, subtree_root_index)
+    deleteat!(edge_set, edge_to_contract)
+
+    edge_to_contract = findprev(edge_set, edge_to_contract - 1)
+  end
+
+  # The level sequence `level_sequence` will not automatically be a canonical
+  # representation.
+  canonical_representation!(skeleton)
+  return skeleton
+end
+
 # PartitionForestIterator
 # PartitionIterator
 

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -332,40 +332,49 @@ end
 
 
 
-# TODO: ColoredRootedTree. partitions
+# partitions
 # We only need to specialize this performance enhancement. The remaining parts
 # are implemented generically.
-# function PartitionIterator(t::RootedTree{Int, Vector{Int}})
-#   order_t = order(t)
+function PartitionIterator(t::ColoredRootedTree{Int, Vector{Int}, Vector{Bool}})
+  order_t = order(t)
 
-#   if order_t <= BUFFER_LENGTH
-#     id = Threads.threadid()
+  if order_t <= BUFFER_LENGTH
+    id = Threads.threadid()
 
-#     buffer_forest_t = PARTITION_ITERATOR_BUFFER_FOREST_T[id]
-#     resize!(buffer_forest_t, order_t)
-#     level_sequence  = PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE[id]
-#     resize!(level_sequence, order_t)
-#     buffer_skeleton = PARTITION_ITERATOR_BUFFER_SKELETON[id]
-#     resize!(buffer_skeleton, order_t)
-#     edge_set        = PARTITION_ITERATOR_BUFFER_EDGE_SET[id]
-#     resize!(edge_set, order_t - 1)
-#     edge_set_tmp    = PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP[id]
-#     resize!(edge_set_tmp, order_t - 1)
-#   else
-#     buffer_forest_t = Vector{Int}(undef, order_t)
-#     level_sequence  = similar(buffer_forest_t)
-#     buffer_skeleton = similar(buffer_forest_t)
-#     edge_set        = Vector{Bool}(undef, order_t - 1)
-#     edge_set_tmp    = similar(edge_set)
-#   end
+    buffer_forest_t        = PARTITION_ITERATOR_BUFFER_FOREST_T[id]
+    resize!(buffer_forest_t, order_t)
+    buffer_forest_t_colors = PARTITION_ITERATOR_BUFFER_FOREST_T_COLORS[id]
+    resize!(buffer_forest_t_colors, order_t)
+    level_sequence         = PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE[id]
+    resize!(level_sequence, order_t)
+    color_sequence         = PARTITION_ITERATOR_BUFFER_FOREST_COLOR_SEQUENCE[id]
+    resize!(color_sequence, order_t)
+    buffer_skeleton        = PARTITION_ITERATOR_BUFFER_SKELETON[id]
+    resize!(buffer_skeleton, order_t)
+    buffer_skeleton_colors = PARTITION_ITERATOR_BUFFER_SKELETON_COLORS[id]
+    resize!(buffer_skeleton_colors, order_t)
+    edge_set                = PARTITION_ITERATOR_BUFFER_EDGE_SET[id]
+    resize!(edge_set, order_t - 1)
+    edge_set_tmp            = PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP[id]
+    resize!(edge_set_tmp, order_t - 1)
+  else
+    buffer_forest_t        = Vector{Int}(undef, order_t)
+    buffer_forest_t_colors = Vector{Bool}(undef, order_t)
+    level_sequence         = similar(buffer_forest_t)
+    color_sequence         = similar(buffer_forest_t_colors)
+    buffer_skeleton        = similar(buffer_forest_t)
+    buffer_skeleton_colors = similar(buffer_forest_t_colors)
+    edge_set               = Vector{Bool}(undef, order_t - 1)
+    edge_set_tmp           = similar(edge_set)
+  end
 
-#   skeleton = RootedTree(buffer_skeleton, true)
-#   t_forest = RootedTree(buffer_forest_t, true)
-#   t_temp_forest = RootedTree(level_sequence, true)
-#   forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
-#   PartitionIterator{Int, RootedTree{Int, Vector{Int}}}(
-#     t, forest, skeleton, edge_set, edge_set_tmp)
-# end
+  skeleton = ColoredRootedTree(buffer_skeleton, buffer_skeleton_colors, true)
+  t_forest = ColoredRootedTree(buffer_forest_t, buffer_forest_t_colors, true)
+  t_temp_forest = ColoredRootedTree(level_sequence, color_sequence, true)
+  forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
+  PartitionIterator{typeof(t), ColoredRootedTree{Int, Vector{Int}, Vector{Bool}}}(
+    t, forest, skeleton, edge_set, edge_set_tmp)
+end
 
 
 

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -82,6 +82,7 @@ iscanonical(t::ColoredRootedTree) = t.iscanonical
 #TODO: Validate rooted tree in constructor?
 
 Base.copy(t::ColoredRootedTree) = ColoredRootedTree(copy(t.level_sequence), copy(t.color_sequence), t.iscanonical)
+Base.similar(t::ColoredRootedTree) = ColoredRootedTree(similar(t.level_sequence), similar(t.color_sequence), true)
 Base.isempty(t::ColoredRootedTree) = isempty(t.level_sequence)
 Base.empty(t::ColoredRootedTree) = ColoredRootedTree(empty(t.level_sequence), empty(t.color_sequence), iscanonical(t))
 
@@ -309,7 +310,9 @@ end
 Returns a vector of all subtrees of `t`.
 """
 function subtrees(t::ColoredRootedTree)
-  subtr = typeof(t)[]
+  subtr = ColoredRootedTree{eltype(t.level_sequence),
+                            Vector{eltype(t.level_sequence)},
+                            Vector{eltype(t.color_sequence)}}[]
 
   if length(t.level_sequence) < 2
     return subtr
@@ -330,9 +333,39 @@ end
 
 
 # TODO: ColoredRootedTree. partitions
-# The partition skeleton is implemented generically.
-# PartitionForestIterator
-# PartitionIterator
+# We only need to specialize this performance enhancement. The remaining parts
+# are implemented generically.
+# function PartitionIterator(t::RootedTree{Int, Vector{Int}})
+#   order_t = order(t)
+
+#   if order_t <= BUFFER_LENGTH
+#     id = Threads.threadid()
+
+#     buffer_forest_t = PARTITION_ITERATOR_BUFFER_FOREST_T[id]
+#     resize!(buffer_forest_t, order_t)
+#     level_sequence  = PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE[id]
+#     resize!(level_sequence, order_t)
+#     buffer_skeleton = PARTITION_ITERATOR_BUFFER_SKELETON[id]
+#     resize!(buffer_skeleton, order_t)
+#     edge_set        = PARTITION_ITERATOR_BUFFER_EDGE_SET[id]
+#     resize!(edge_set, order_t - 1)
+#     edge_set_tmp    = PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP[id]
+#     resize!(edge_set_tmp, order_t - 1)
+#   else
+#     buffer_forest_t = Vector{Int}(undef, order_t)
+#     level_sequence  = similar(buffer_forest_t)
+#     buffer_skeleton = similar(buffer_forest_t)
+#     edge_set        = Vector{Bool}(undef, order_t - 1)
+#     edge_set_tmp    = similar(edge_set)
+#   end
+
+#   skeleton = RootedTree(buffer_skeleton, true)
+#   t_forest = RootedTree(buffer_forest_t, true)
+#   t_temp_forest = RootedTree(level_sequence, true)
+#   forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
+#   PartitionIterator{Int, RootedTree{Int, Vector{Int}}}(
+#     t, forest, skeleton, edge_set, edge_set_tmp)
+# end
 
 
 

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -129,6 +129,9 @@ function Base.isless(t1::ColoredRootedTree, t2::ColoredRootedTree)
     v2 = e2 + root1_minus_root2
     (v1 == v2) || return isless(v1, v2)
   end
+  if length(t1.level_sequence) != length(t2.level_sequence)
+    return isless(length(t1.level_sequence), length(t2.level_sequence))
+  end
   return isless(t1.color_sequence, t2.color_sequence)
 end
 
@@ -183,6 +186,7 @@ function canonical_representation!(t::ColoredRootedTree)
   i = 2
   for τ in subtr
     t.level_sequence[i:i+order(τ)-1] = τ.level_sequence
+    t.color_sequence[i:i+order(τ)-1] = τ.color_sequence
     i += order(τ)
   end
 

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -14,7 +14,7 @@ RecipesBase.@recipe function plot(t::ColoredRootedTree)
   # Series properties
   linecolor --> :black
   markercolor --> reshape(colors, 1, :)
-  background_color --> "light gray"
+  background_color --> "LightGray"
   markershape --> :circle
   markersize  --> 6
   linewidth   --> 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -805,12 +805,11 @@ end # @testset "RootedTree"
     # Example in Section 6.1
     let t = rootedtree([1, 2, 3, 3], Bool[0, 1, 0, 0])
       edge_set = [false, true, false]
-      # TODO
-      # reference_forest = [rootedtree([1, 2, 3]),
-      #                     rootedtree([4]),
-      #                     rootedtree([3])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([3], Bool[0]),
+                          rootedtree([2, 3], Bool[1, 0]),
+                          rootedtree([1], Bool[0])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3], Bool[0, 1, 0])
       @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -819,12 +818,11 @@ end # @testset "RootedTree"
     # Other examples for single-colored trees
     let t = rootedtree([1, 2, 3, 4, 3], Bool[1, 1, 0, 1, 1])
       edge_set = [true, true, false, false]
-      # TODO
-      # reference_forest = [rootedtree([1, 2, 3]),
-      #                     rootedtree([4]),
-      #                     rootedtree([3])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([1, 2, 3], Bool[1, 1, 0]),
+                          rootedtree([4], Bool[1]),
+                          rootedtree([3], Bool[1])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 2])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -832,12 +830,11 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
       edge_set = [false, true, true, false]
-      # TODO
-      # reference_forest = [rootedtree([3]),
-      #                     rootedtree([2, 3, 4]),
-      #                     rootedtree([1])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                          rootedtree([2, 3, 4], t.color_sequence[2:4]),
+                          rootedtree([1], t.color_sequence[1:1])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -845,13 +842,12 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
       edge_set = [false, true, false, false]
-      # TODO
-      # reference_forest = [rootedtree([4]),
-      #                     rootedtree([3]),
-      #                     rootedtree([2, 3]),
-      #                     rootedtree([1])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([4], t.color_sequence[4:4]),
+                          rootedtree([3], t.color_sequence[5:5]),
+                          rootedtree([2, 3], t.color_sequence[2:3]),
+                          rootedtree([1], t.color_sequence[1:1])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3, 3])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -859,12 +855,11 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 2, 2, 2], rand(Bool, 5))
       edge_set = [false, false, true, true]
-      # TODO
-      # reference_forest = [rootedtree([2]),
-      #                     rootedtree([2]),
-      #                     rootedtree([1, 2, 2])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([2], t.color_sequence[2:2]),
+                          rootedtree([2], t.color_sequence[3:3]),
+                          rootedtree([1, 2, 2], t.color_sequence[[1,4,5]])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 2])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -872,13 +867,12 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
       edge_set = [false, false, false, true]
-      # TODO
-      # reference_forest = [rootedtree([3]),
-      #                     rootedtree([2]),
-      #                     rootedtree([2]),
-      #                     rootedtree([1, 2])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([3], t.color_sequence[3:3]),
+                          rootedtree([2], t.color_sequence[2:2]),
+                          rootedtree([2], t.color_sequence[4:4]),
+                          rootedtree([1, 2], t.color_sequence[[1, 5]])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3, 2])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -886,10 +880,9 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
       edge_set = [true, true, true, true]
-      # TODO
-      # reference_forest = [rootedtree([1, 2, 3, 2, 2])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([1, 2, 3, 2, 2], t.color_sequence[:])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -897,12 +890,11 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
       edge_set = [true, true, false, false]
-      # TODO
-      # reference_forest = [rootedtree([3]),
-      #                     rootedtree([2]),
-      #                     rootedtree([1, 2, 3])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                          rootedtree([2], t.color_sequence[4:4]),
+                          rootedtree([1, 2, 3], t.color_sequence[1:3])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -910,13 +902,12 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
       edge_set = [false, true, false, false]
-      # TODO
-      # reference_forest = [rootedtree([2, 3]),
-      #                     rootedtree([3]),
-      #                     rootedtree([2]),
-      #                     rootedtree([1])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([2, 3], t.color_sequence[2:3]),
+                          rootedtree([3], t.color_sequence[5:5]),
+                          rootedtree([2], t.color_sequence[4:4]),
+                          rootedtree([1], t.color_sequence[1:1])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 2, 3])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -924,12 +915,11 @@ end # @testset "RootedTree"
 
     let t = rootedtree([1, 2, 3, 3, 3], rand(Bool, 5))
       edge_set = [false, true, true, false]
-      # TODO
-      # reference_forest = [rootedtree([3]),
-      #                     rootedtree([2, 3, 3]),
-      #                     rootedtree([1])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                          rootedtree([2, 3, 3], t.color_sequence[2:4]),
+                          rootedtree([1], t.color_sequence[1:1])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2, 3])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
@@ -938,11 +928,10 @@ end # @testset "RootedTree"
     # additional tests not included in the examples of the paper
     let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
       edge_set = [true, false, true, true]
-      # TODO
-      # reference_forest = [rootedtree([1, 2, 3, 2]),
-      #                     rootedtree([3])]
-      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+      reference_forest = [rootedtree([1, 2, 3, 2], t.color_sequence[[1, 4, 5, 2]]),
+                          rootedtree([3], t.color_sequence[3:3])]
+      sort!(reference_forest)
+      @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
       reference_skeleton = rootedtree([1, 2])
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -789,6 +789,148 @@ end # @testset "RootedTree"
       @test num == number_of_rooted_trees[order] * 2^order
     end
   end
+
+  # See Sections 2.3 & 6.1 and Table 2 of
+  # - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  #   Algebraic Structures of B-series.
+  #   Foundations of Computational Mathematics
+  #   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+  @testset "partitions" begin
+    # Example in Section 6.1
+    let t = rootedtree([1, 2, 3, 3], Bool[0, 1, 0, 0])
+      edge_set = [false, true, false]
+      # reference_forest = [rootedtree([1, 2, 3]),
+      #                     rootedtree([4]),
+      #                     rootedtree([3])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+      reference_skeleton = rootedtree([1, 2, 3], Bool[0, 1, 0])
+      @test reference_skeleton == partition_skeleton(t, edge_set)
+    end
+
+  #   # Other examples for single-colored trees
+  #   let t = rootedtree([1, 2, 3, 4, 3])
+  #     edge_set = [true, true, false, false]
+  #     reference_forest = [rootedtree([1, 2, 3]),
+  #                         rootedtree([4]),
+  #                         rootedtree([3])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 2])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 4, 3])
+  #     edge_set = [false, true, true, false]
+  #     reference_forest = [rootedtree([3]),
+  #                         rootedtree([2, 3, 4]),
+  #                         rootedtree([1])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 3])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 4, 3])
+  #     edge_set = [false, true, false, false]
+  #     reference_forest = [rootedtree([4]),
+  #                         rootedtree([3]),
+  #                         rootedtree([2, 3]),
+  #                         rootedtree([1])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 3, 3])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 2, 2, 2])
+  #     edge_set = [false, false, true, true]
+  #     reference_forest = [rootedtree([2]),
+  #                         rootedtree([2]),
+  #                         rootedtree([1, 2, 2])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 2])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 2, 2])
+  #     edge_set = [false, false, false, true]
+  #     reference_forest = [rootedtree([3]),
+  #                         rootedtree([2]),
+  #                         rootedtree([2]),
+  #                         rootedtree([1, 2])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 3, 2])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 2, 2])
+  #     edge_set = [true, true, true, true]
+  #     reference_forest = [rootedtree([1, 2, 3, 2, 2])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 2, 3])
+  #     edge_set = [true, true, false, false]
+  #     reference_forest = [rootedtree([3]),
+  #                         rootedtree([2]),
+  #                         rootedtree([1, 2, 3])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 3])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 2, 3])
+  #     edge_set = [false, true, false, false]
+  #     reference_forest = [rootedtree([2, 3]),
+  #                         rootedtree([3]),
+  #                         rootedtree([2]),
+  #                         rootedtree([1])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 2, 3])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   let t = rootedtree([1, 2, 3, 3, 3])
+  #     edge_set = [false, true, true, false]
+  #     reference_forest = [rootedtree([3]),
+  #                         rootedtree([2, 3, 3]),
+  #                         rootedtree([1])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2, 3])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+
+  #   # additional tests not included in the examples of the paper
+  #   let t = rootedtree([1, 2, 3, 2, 3])
+  #     edge_set = [true, false, true, true]
+  #     reference_forest = [rootedtree([1, 2, 3, 2]),
+  #                         rootedtree([3])]
+  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+
+  #     reference_skeleton = rootedtree([1, 2])
+  #     @test reference_skeleton == partition_skeleton(t, edge_set)
+  #   end
+  # end
 end # @testset "ColoredRootedTree"
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -635,7 +635,13 @@ end # @testset "RootedTree"
       println(devnull, t8)
     end
 
+    @test rootedtree([1, 2]            ) > rootedtree([1]         )
+    @test rootedtree([1, 2], Bool[0, 1]) > rootedtree([1], Bool[1])
+
     # more tests of the canonical representation
+    t = rootedtree([1, 2, 3, 4, 3], Bool[1, 1, 0, 1, 1])
+    @test t.level_sequence == [1, 2, 3, 4, 3]
+
     t = rootedtree([1, 2, 3, 2, 3, 3, 2], Bool[1, 0, 1, 1, 0, 0, 0])
     @test t.level_sequence == [1, 2, 3, 3, 2, 3, 2]
     @test !isempty(t)
@@ -764,7 +770,7 @@ end # @testset "RootedTree"
       @test σ(t) == 1
       @test γ(t) == 3
       @test_nowarn println(devnull, t)
-      @test butcher_representation(t) == "[τ₁τ₂]₂"
+      @test butcher_representation(t) == "[τ₂τ₁]₂"
     end
 
     let t = rootedtree([1, 2, 3], [3, 2, 1])
@@ -799,6 +805,7 @@ end # @testset "RootedTree"
     # Example in Section 6.1
     let t = rootedtree([1, 2, 3, 3], Bool[0, 1, 0, 0])
       edge_set = [false, true, false]
+      # TODO
       # reference_forest = [rootedtree([1, 2, 3]),
       #                     rootedtree([4]),
       #                     rootedtree([3])]
@@ -809,128 +816,138 @@ end # @testset "RootedTree"
       @test reference_skeleton == partition_skeleton(t, edge_set)
     end
 
-  #   # Other examples for single-colored trees
-  #   let t = rootedtree([1, 2, 3, 4, 3])
-  #     edge_set = [true, true, false, false]
-  #     reference_forest = [rootedtree([1, 2, 3]),
-  #                         rootedtree([4]),
-  #                         rootedtree([3])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    # Other examples for single-colored trees
+    let t = rootedtree([1, 2, 3, 4, 3], Bool[1, 1, 0, 1, 1])
+      edge_set = [true, true, false, false]
+      # TODO
+      # reference_forest = [rootedtree([1, 2, 3]),
+      #                     rootedtree([4]),
+      #                     rootedtree([3])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 2])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 2])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 4, 3])
-  #     edge_set = [false, true, true, false]
-  #     reference_forest = [rootedtree([3]),
-  #                         rootedtree([2, 3, 4]),
-  #                         rootedtree([1])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
+      edge_set = [false, true, true, false]
+      # TODO
+      # reference_forest = [rootedtree([3]),
+      #                     rootedtree([2, 3, 4]),
+      #                     rootedtree([1])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 3])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 4, 3])
-  #     edge_set = [false, true, false, false]
-  #     reference_forest = [rootedtree([4]),
-  #                         rootedtree([3]),
-  #                         rootedtree([2, 3]),
-  #                         rootedtree([1])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
+      edge_set = [false, true, false, false]
+      # TODO
+      # reference_forest = [rootedtree([4]),
+      #                     rootedtree([3]),
+      #                     rootedtree([2, 3]),
+      #                     rootedtree([1])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 3, 3])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 3, 3])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 2, 2, 2])
-  #     edge_set = [false, false, true, true]
-  #     reference_forest = [rootedtree([2]),
-  #                         rootedtree([2]),
-  #                         rootedtree([1, 2, 2])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 2, 2, 2], rand(Bool, 5))
+      edge_set = [false, false, true, true]
+      # TODO
+      # reference_forest = [rootedtree([2]),
+      #                     rootedtree([2]),
+      #                     rootedtree([1, 2, 2])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 2])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 2])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 2, 2])
-  #     edge_set = [false, false, false, true]
-  #     reference_forest = [rootedtree([3]),
-  #                         rootedtree([2]),
-  #                         rootedtree([2]),
-  #                         rootedtree([1, 2])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
+      edge_set = [false, false, false, true]
+      # TODO
+      # reference_forest = [rootedtree([3]),
+      #                     rootedtree([2]),
+      #                     rootedtree([2]),
+      #                     rootedtree([1, 2])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 3, 2])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 3, 2])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 2, 2])
-  #     edge_set = [true, true, true, true]
-  #     reference_forest = [rootedtree([1, 2, 3, 2, 2])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
+      edge_set = [true, true, true, true]
+      # TODO
+      # reference_forest = [rootedtree([1, 2, 3, 2, 2])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 2, 3])
-  #     edge_set = [true, true, false, false]
-  #     reference_forest = [rootedtree([3]),
-  #                         rootedtree([2]),
-  #                         rootedtree([1, 2, 3])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
+      edge_set = [true, true, false, false]
+      # TODO
+      # reference_forest = [rootedtree([3]),
+      #                     rootedtree([2]),
+      #                     rootedtree([1, 2, 3])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 3])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 2, 3])
-  #     edge_set = [false, true, false, false]
-  #     reference_forest = [rootedtree([2, 3]),
-  #                         rootedtree([3]),
-  #                         rootedtree([2]),
-  #                         rootedtree([1])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
+      edge_set = [false, true, false, false]
+      # TODO
+      # reference_forest = [rootedtree([2, 3]),
+      #                     rootedtree([3]),
+      #                     rootedtree([2]),
+      #                     rootedtree([1])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 2, 3])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 2, 3])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   let t = rootedtree([1, 2, 3, 3, 3])
-  #     edge_set = [false, true, true, false]
-  #     reference_forest = [rootedtree([3]),
-  #                         rootedtree([2, 3, 3]),
-  #                         rootedtree([1])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    let t = rootedtree([1, 2, 3, 3, 3], rand(Bool, 5))
+      edge_set = [false, true, true, false]
+      # TODO
+      # reference_forest = [rootedtree([3]),
+      #                     rootedtree([2, 3, 3]),
+      #                     rootedtree([1])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2, 3])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
+      reference_skeleton = rootedtree([1, 2, 3])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
 
-  #   # additional tests not included in the examples of the paper
-  #   let t = rootedtree([1, 2, 3, 2, 3])
-  #     edge_set = [true, false, true, true]
-  #     reference_forest = [rootedtree([1, 2, 3, 2]),
-  #                         rootedtree([3])]
-  #     @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
-  #     @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
+    # additional tests not included in the examples of the paper
+    let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
+      edge_set = [true, false, true, true]
+      # TODO
+      # reference_forest = [rootedtree([1, 2, 3, 2]),
+      #                     rootedtree([3])]
+      # @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
+      # @test sort!(collect(PartitionForestIterator(t, edge_set))) == reference_forest
 
-  #     reference_skeleton = rootedtree([1, 2])
-  #     @test reference_skeleton == partition_skeleton(t, edge_set)
-  #   end
-  # end
+      reference_skeleton = rootedtree([1, 2])
+      @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
+    end
+  end
 end # @testset "ColoredRootedTree"
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -937,6 +937,66 @@ end # @testset "RootedTree"
       @test reference_skeleton.level_sequence == partition_skeleton(t, edge_set).level_sequence
     end
   end
+
+  # See Table 3 of
+  # - Philippe Chartier, Ernst Hairer, Gilles Vilmart (2010)
+  #   Algebraic Structures of B-series.
+  #   Foundations of Computational Mathematics
+  #   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
+  @testset "PartitionIterator" begin
+    t = rootedtree([1, 2, 3, 3], Bool[1, 0, 1, 0])
+    partitions = collect(PartitionIterator(t))
+    forests = map(first, partitions)
+    skeletons = map(last, partitions)
+    for forest in forests
+      for tree in forest
+        RootedTrees.normalize_root!(tree)
+      end
+      sort!(forest)
+    end
+    sort!(forests)
+    for tree in skeletons
+      RootedTrees.normalize_root!(tree)
+    end
+    sort!(skeletons)
+
+    reference_forests = [
+      [rootedtree([1, 2, 3, 3], Bool[1, 0, 1, 0]),],
+      [rootedtree([1], Bool[1]), rootedtree([1, 2, 2], Bool[0, 1, 0])],
+      [rootedtree([1], Bool[1]), rootedtree([1, 2, 3], Bool[1, 0, 0])],
+      [rootedtree([1], Bool[0]), rootedtree([1, 2, 3], Bool[1, 0, 1]),],
+      [rootedtree([1], Bool[1]), rootedtree([1], Bool[1]), rootedtree([1, 2], Bool[0, 0])],
+      [rootedtree([1], Bool[0]), rootedtree([1], Bool[1]), rootedtree([1, 2], Bool[1, 0])],
+      [rootedtree([1], Bool[0]), rootedtree([1], Bool[1]), rootedtree([1, 2], Bool[0, 1])],
+      [rootedtree([1], Bool[0]), rootedtree([1], Bool[0]), rootedtree([1], Bool[1]), rootedtree([1], Bool[1])],
+    ]
+    reference_skeletons = [
+      rootedtree([1], Bool[1]),
+      rootedtree([1, 2], Bool[1, 0]),
+      rootedtree([1, 2], Bool[1, 0]),
+      rootedtree([1, 2], Bool[1, 1]),
+      rootedtree([1, 2, 2], Bool[1, 1, 0]),
+      rootedtree([1, 2, 3], Bool[1, 0, 0]),
+      rootedtree([1, 2, 3], Bool[1, 0, 1]),
+      rootedtree([1, 2, 3, 3], Bool[1, 0, 1, 0]),
+    ]
+    for forest in reference_forests
+      sort!(forest)
+    end
+    sort!(reference_forests)
+    sort!(reference_skeletons)
+
+    @test forests == reference_forests
+    @test skeletons == reference_skeletons
+
+    level_sequence = zeros(Int, RootedTrees.BUFFER_LENGTH + 1)
+    level_sequence[1] -= 1
+    color_sequence = rand(Bool, length(level_sequence))
+    t = rootedtree(level_sequence, color_sequence)
+    @inferred PartitionIterator(t)
+    t = @inferred rootedtree!(view(level_sequence, :), view(color_sequence, :))
+    @inferred PartitionIterator(t)
+  end
 end # @testset "ColoredRootedTree"
 
 


### PR DESCRIPTION
## TODO

- [x] create some `unsafe_deleteat!(::AbstractRootedTree, i)` to allow more code reuse? This would be `deleteat!(t.level_sequnce, i)` for `RootedTree`s and also update the `color_sequence` of colored trees. Then, we could basically reuse `partition_skeleton!`. However, it's unsafe since the trees will not be balanced after this operation.
- [x] `PartitionForestIterator`
- [x] `PartitionIterator`
- [x] Buffer for `PartitionIterator`