### PR TITLE
make use of black/white consistent for bicolored tree plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootedTrees"
 uuid = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "2.9.1"
+version = "2.9.2"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -4,7 +4,11 @@ RecipesBase.@recipe function plot(t::ColoredRootedTree)
   width = 2.0
   height = 1.0
   color_idx = unique(t.color_sequence)
-  color_val = Plots.distinguishable_colors(length(color_idx))
+  if eltype(t.color_sequence) == Bool
+    color_val = [:white, :black]
+  else
+    color_val = Plots.distinguishable_colors(length(color_idx))
+  end
   colormap = Dict{eltype(color_idx), eltype(color_val)}()
   for (idx, val) in zip(color_idx, color_val)
     colormap[idx] = val


### PR DESCRIPTION
`false` is black, `true` is white.