### PR TITLE
new latexify setup to support colored trees

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootedTrees"
 uuid = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "2.15.2"
+version = "2.16.0"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Additionally, functions on trees connected to Runge-Kutta methods are implemente
 
 ## Brief Changelog
 
+- v2.16: The LaTeX printing of rooted trees changed to allow representing
+  colored rooted trees. Please update your LaTeX preamble as described in
+  the docstring of `RootedTrees.latexify`.
 - v2.0: Rooted trees are considered up to isomorphisms introduced by shifting
   each coefficient of their level sequence by the same number.
 

--- a/docs/src/tutorials/basics.md
+++ b/docs/src/tutorials/basics.md
@@ -123,6 +123,14 @@ for t in BicoloredRootedTreeIterator(3)
 end
 ```
 
+[`RootedTrees.latexify`](@ref) also supports bicolored rooted trees:
+
+```@example basics
+for t in BicoloredRootedTreeIterator(3)
+    println(RootedTrees.latexify(t))
+end
+```
+
 ```@example basics
 using Plots
 t = rootedtree([1, 2, 3, 3, 2, 2], Bool[0, 0, 1, 0, 1, 0])

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -658,7 +658,9 @@ Section 2.3 of
   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
 """
 function partition_forest(t::RootedTree, edge_set)
-    @boundscheck begin @assert length(t.level_sequence) == length(edge_set) + 1 end
+    @boundscheck begin
+        @assert length(t.level_sequence) == length(edge_set) + 1
+    end
 
     level_sequence = copy(t.level_sequence)
     edge_set_copy = copy(edge_set)
@@ -800,7 +802,9 @@ Section 2.3 (and Section 6.1 for colored trees) of
   [DOI: 10.1007/s10208-010-9065-1](https://doi.org/10.1007/s10208-010-9065-1)
 """
 function partition_skeleton(t::AbstractRootedTree, edge_set)
-    @boundscheck begin @assert order(t) == length(edge_set) + 1 end
+    @boundscheck begin
+        @assert order(t) == length(edge_set) + 1
+    end
 
     edge_set_copy = copy(edge_set)
     skeleton = copy(t)

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -54,24 +54,24 @@ function latexify(t::RootedTree)
 end
 
 function latexify(t::BicoloredRootedTree)
-  if isempty(t)
-      return "\\varnothing"
-  end
-  list_representation = butcher_representation(rootedtree(t.level_sequence), false)
-  s = "\\rootedtree" * replace(list_representation, "τ" => "[]")
-  # The first entry of `substrings` is "\\rootedtree".
-  substrings = split(s, "[")
-  strings = String[]
-  for (color, substring) in zip(t.color_sequence, substrings)
-    if color == false
-      push!(strings, substring * "[.")
-    elseif color == true
-      push!(strings, substring * "[o")
+    if isempty(t)
+        return "\\varnothing"
     end
-  end
-  # We still need to add the last part dropped by `zip`.
-  push!(strings, last(substrings))
-  return join(strings)
+    list_representation = butcher_representation(rootedtree(t.level_sequence), false)
+    s = "\\rootedtree" * replace(list_representation, "τ" => "[]")
+    # The first entry of `substrings` is "\\rootedtree".
+    substrings = split(s, "[")
+    strings = String[]
+    for (color, substring) in zip(t.color_sequence, substrings)
+        if color == false
+            push!(strings, substring * "[.")
+        elseif color == true
+            push!(strings, substring * "[o")
+        end
+    end
+    # We still need to add the last part dropped by `zip`.
+    push!(strings, last(substrings))
+    return join(strings)
 end
 
 Latexify.@latexrecipe function _(t::Union{RootedTree, BicoloredRootedTree})

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -1,6 +1,6 @@
 
 """
-    latexify(t::RootedTree)
+    latexify(t::Union{RootedTree, BicoloredRootedTree})
 
 Return a LaTeX representation of the rooted tree `t`. This makes use of the
 LaTeX package [forest](https://ctan.org/pkg/forest) and assumes that you use
@@ -53,6 +53,27 @@ function latexify(t::RootedTree)
     return replace(s, "[" => "[.")
 end
 
-Latexify.@latexrecipe function _(t::RootedTree)
+function latexify(t::BicoloredRootedTree)
+  if isempty(t)
+      return "\\varnothing"
+  end
+  list_representation = butcher_representation(rootedtree(t.level_sequence), false)
+  s = "\\rootedtree" * replace(list_representation, "τ" => "[]")
+  # The first entry of `substrings` is "\\rootedtree".
+  substrings = split(s, "[")
+  strings = String[]
+  for (color, substring) in zip(t.color_sequence, substrings)
+    if color == false
+      push!(strings, substring * "[.")
+    elseif color == true
+      push!(strings, substring * "[o")
+    end
+  end
+  # We still need to add the last part dropped by `zip`.
+  push!(strings, last(substrings))
+  return join(strings)
+end
+
+Latexify.@latexrecipe function _(t::Union{RootedTree, BicoloredRootedTree})
     return Latexify.LaTeXString(RootedTrees.latexify(t))
 end

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -24,8 +24,8 @@ the following LaTeX code in the preamble.
         for children={no edge, before drawing tree={for tree={y-=5pt}}}
       }
       {
-        where content={o}{content={\blankforrootedtree}, whitenode}{
-          where content={.}{content={\blankforrootedtree}, blacknode}{}
+        where content={o}{content={\\blankforrootedtree}, whitenode}{
+          where content={.}{content={\\blankforrootedtree}, blacknode}{}
         }
       }
     }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -866,7 +866,8 @@ using Aqua: Aqua
                 @test latexify(t) == latex_string
             end
 
-            let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2], Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+            let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
+                               Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
                 latex_string = "\\rootedtree[.[o[.[o][.]][o[.]][o][.]][o]]"
                 @test latexify(t) == latex_string
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -830,6 +830,48 @@ using Aqua: Aqua
             end
         end
 
+        @testset "latexify" begin
+            let t = rootedtree(Int[], Bool[])
+                latex_string = "\\varnothing"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1], Bool[0])
+                latex_string = "\\rootedtree[.]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1], Bool[1])
+                latex_string = "\\rootedtree[o]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1, 2], Bool[0, 0])
+                latex_string = "\\rootedtree[.[.]]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1, 2], Bool[1, 0])
+                latex_string = "\\rootedtree[o[.]]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1, 2], Bool[0, 1])
+                latex_string = "\\rootedtree[.[o]]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1, 2], Bool[1, 1])
+                latex_string = "\\rootedtree[o[o]]"
+                @test latexify(t) == latex_string
+            end
+
+            let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2], Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+                latex_string = "\\rootedtree[.[o[.[o][.]][o[.]][o][.]][o]]"
+                @test latexify(t) == latex_string
+            end
+        end
+
         # see butcher2008numerical, Table 302(I)
         @testset "number of trees" begin
             number_of_rooted_trees = [1, 1, 1, 2, 4, 9, 20, 48, 115, 286, 719]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,7 +151,7 @@ using Aqua: Aqua
             @test α(t1) == 1
             @test β(t1) == α(t1) * γ(t1)
             @test butcher_representation(t1) == "τ"
-            latex_string = "\\rootedtree[]"
+            latex_string = "\\rootedtree[.]"
             @test RootedTrees.latexify(t1) == latex_string
             @test latexify(t1) == latex_string
             @test isempty(RootedTrees.subtrees(t1))
@@ -173,7 +173,7 @@ using Aqua: Aqua
             @test β(t2) == α(t2) * γ(t2)
             @test t2 == t1 ∘ t1
             @test butcher_representation(t2) == "[τ]"
-            latex_string = "\\rootedtree[[]]"
+            latex_string = "\\rootedtree[.[.]]"
             @test RootedTrees.latexify(t2) == latex_string
             @test latexify(t2) == latex_string
             @test RootedTrees.subtrees(t2) == [rootedtree([2])]
@@ -186,7 +186,7 @@ using Aqua: Aqua
             @test β(t3) == α(t3) * γ(t3)
             @test t3 == t2 ∘ t1
             @test butcher_representation(t3) == "[τ²]"
-            latex_string = "\\rootedtree[[][]]"
+            latex_string = "\\rootedtree[.[.][.]]"
             @test RootedTrees.latexify(t3) == latex_string
             @test latexify(t3) == latex_string
             @test RootedTrees.subtrees(t3) == [rootedtree([2]), rootedtree([2])]
@@ -199,7 +199,7 @@ using Aqua: Aqua
             @test β(t4) == α(t4) * γ(t4)
             @test t4 == t1 ∘ t2
             @test butcher_representation(t4) == "[[τ]]"
-            latex_string = "\\rootedtree[[[]]]"
+            latex_string = "\\rootedtree[.[.[.]]]"
             @test RootedTrees.latexify(t4) == latex_string
             @test latexify(t4) == latex_string
             @test RootedTrees.subtrees(t4) == [rootedtree([2, 3])]


### PR DESCRIPTION
This allows us to create LaTeX code rendered as follows:

![rooted_trees-1](https://user-images.githubusercontent.com/12693098/216765237-0ec1138f-e3bb-45e4-bc81-9de6a3904e46.jpg)

Code to reproduce:

```julia
julia> using BSeries, Latexify

julia> ark = let # Störmer-Verlet method
       As = [
           [0 0; 1//2 1//2],
           [1//2 0; 1//2 0],
       ]
       bs = [
           [1 // 2, 1 // 2],
           [1 // 2, 1 // 2],
       ]
       AdditiveRungeKuttaMethod(As, bs)
       end

julia> series = bseries(ark, 3)

julia> latexify(series; cdot = false)
```

Compared to the previous version, the LaTeX code of plain (single-colored) rooted trees is a bit more verbose since it includes an additional `.` after each opening bracket `[`, e.g., 

```julia
julia> using RootedTrees

julia> t = rootedtree([1, 2, 2])
RootedTree{Int64}: [1, 2, 2]

julia> RootedTrees.latexify(t) |> println
\rootedtree[.[.][.]]
```