### PR TITLE
allow building the docs locally

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,13 @@
 using Documenter
 import Pkg
+
+# Fix for https://github.com/trixi-framework/Trixi.jl/issues/668
+# to allow building the docs locally
+if (get(ENV, "CI", nothing) != "true") &&
+   (get(ENV, "JULIA_DOC_DEFAULT_ENVIRONMENT", nothing) != "true")
+    push!(LOAD_PATH, dirname(@__DIR__))
+end
+
 using RootedTrees
 
 # Define module-wide setups such that the respective modules are available in doctests


### PR DESCRIPTION
If sympy (from python) is installed correctly, this allows to build the docs locally using

```julia
using Pkg
Pkg.activate("docs")
Pkg.update()
include("docs/make.jl")
```

CC @pw0lf