### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -24,8 +23,7 @@ LinearAlgebra = "1"
 Plots = "1"
 Preferences = "1.3"
 RecipesBase = "1"
-Requires = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -1,9 +1,6 @@
 module PlotsExt
 
-    using Plots: Plots
-else
-    import ..Plots: Plots
-end
+using Plots: Plots
 
 using RootedTrees: RootedTrees
 

--- a/ext/PlotsExt.jl
+++ b/ext/PlotsExt.jl
@@ -1,6 +1,5 @@
 module PlotsExt
 
-if isdefined(Base, :get_extension)
     using Plots: Plots
 else
     import ..Plots: Plots

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -10,10 +10,6 @@ using Latexify: Latexify
 using Preferences: @set_preferences!, @load_preference
 using RecipesBase: RecipesBase
 
-if !isdefined(Base, :get_extension)
-    using Requires: @require
-end
-
 export RootedTree, rootedtree, rootedtree!, RootedTreeIterator,
        ColoredRootedTree, BicoloredRootedTree, BicoloredRootedTreeIterator
 
@@ -1604,16 +1600,7 @@ function __init__()
     Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
                              Vector{Bool}(undef, BUFFER_LENGTH))
 
-    @static if !isdefined(Base, :get_extension)
-        @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" begin
-            include("../ext/PlotsExt.jl")
-        end
-    end
-
-    return nothing
-end
-
-# explicit precompilation on Julia v1.8 and newer
+    @static # explicit precompilation on Julia v1.8 and newer
 @static if VERSION >= v"1.8"
     include("precompile.jl")
 end

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -1600,7 +1600,8 @@ function __init__()
     Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
                              Vector{Bool}(undef, BUFFER_LENGTH))
 
-    @static # explicit precompilation on Julia v1.8 and newer
+    return nothing
+end
 @static if VERSION >= v"1.8"
     include("precompile.jl")
 end

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -1602,7 +1602,6 @@ function __init__()
 
     return nothing
 end
-                              
 # explicit precompilation
 include("precompile.jl")
 


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks