### PR TITLE
fix(ci): use correct default branch in workflows

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   doc-preview-cleanup:
     # Do not run on forks to avoid authorization errors
-    # Source: https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18
+    # Source: https://github.community/t/have-github-action-only-run-on-main-repo-and-not-on-forks/140840/18
     if: github.repository_owner == 'SciML'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,12 +2,12 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
This PR fixes the CI workflows to use the correct default branch. Committed by RooCode, an AI tool.