### PR TITLE
Add ExplicitImports.jl tests to CI

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -8,6 +9,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 Aqua = "0.8"
+ExplicitImports = "1"
 LaTeXStrings = "1.2"
 Plots = "1.39"
 StaticArrays = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ Plots.unicodeplots()
 using LaTeXStrings: @L_str
 
 using Aqua: Aqua
+using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_imports
 
 @testset "RootedTrees" begin
     @testset "RootedTree" begin
@@ -1890,5 +1891,10 @@ using Aqua: Aqua
                       ambiguities = (; exclude = [getindex]),
                       # Requires.jl is not loaded on new versions of Julia
                       stale_deps = (; ignore = [:Requires]))
+    end
+
+    @testset "ExplicitImports" begin
+        @test isnothing(check_no_implicit_imports(RootedTrees))
+        @test isnothing(check_no_stale_explicit_imports(RootedTrees))
     end
 end # @testset "RootedTrees"


### PR DESCRIPTION
## Summary

- RootedTrees.jl already passes all ExplicitImports checks (no implicit imports, no stale explicit imports)
- Added ExplicitImports.jl tests to CI to maintain import hygiene going forward
- Added `ExplicitImports` to test dependencies in `test/Project.toml`
- Added `ExplicitImports` testset to `test/runtests.jl`

## Changes

**test/Project.toml:**
- Added `ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"` to `[deps]`
- Added `ExplicitImports = "1"` to `[compat]`

**test/runtests.jl:**
- Added import: `using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_imports`
- Added testset:
```julia
@testset "ExplicitImports" begin
    @test isnothing(check_no_implicit_imports(RootedTrees))
    @test isnothing(check_no_stale_explicit_imports(RootedTrees))
end
```

## Test plan

- [x] Run `Pkg.test()` locally - all tests pass (580,749 tests passed)
- [x] ExplicitImports checks pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)