### PR TITLE
Add JET.jl static analysis tests and fix type stability issue

### DIFF
--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -1254,7 +1254,10 @@ function symmetry(t::AbstractRootedTree)
 
     # Unroll the `for` loop manually to be able to compare the next iterate with
     # the previous one.
-    previous_subtree, state = iterate(subtrees)
+    first_iter = iterate(subtrees)
+    # This should never be `nothing` since order(t) >= 3 implies at least one subtree
+    first_iter === nothing && error("Unexpected: tree with order >= 3 has no subtrees")
+    previous_subtree, state = first_iter
 
     result = 1
     num_same_subtrees = 1

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -8,6 +9,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
 LaTeXStrings = "1.2"
 Plots = "1.39"
 StaticArrays = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1885,6 +1885,34 @@ using Aqua: Aqua
         end
     end # @testset "plots"
 
+    @testset "JET static analysis" begin
+        using JET: JET, report_call, get_reports
+
+        # Test key functions for type stability using report_call
+        @testset "Type stability" begin
+            t = rootedtree([1, 2, 3, 2])
+            t2 = rootedtree([1, 2])
+            ct = rootedtree([1, 2, 3, 2], Bool[false, true, true, false])
+
+            # Core functions should have no JET issues
+            @test isempty(get_reports(report_call(order, (typeof(t),))))
+            @test isempty(get_reports(report_call(symmetry, (typeof(t),))))
+            @test isempty(get_reports(report_call(density, (typeof(t),))))
+            @test isempty(get_reports(report_call(α, (typeof(t),))))
+            @test isempty(get_reports(report_call(β, (typeof(t),))))
+
+            # Iterators should have no JET issues
+            @test isempty(get_reports(report_call(RootedTreeIterator, (Int,))))
+            @test isempty(get_reports(report_call(SubtreeIterator, (typeof(t),))))
+
+            # Colored tree operations should have no JET issues
+            @test isempty(get_reports(report_call(order, (typeof(ct),))))
+            @test isempty(get_reports(report_call(symmetry, (typeof(ct),))))
+            @test isempty(get_reports(report_call(density, (typeof(ct),))))
+            @test isempty(get_reports(report_call(BicoloredRootedTreeIterator, (Int,))))
+        end
+    end
+
     @testset "Aqua" begin
         Aqua.test_all(RootedTrees;
                       ambiguities = (; exclude = [getindex]),


### PR DESCRIPTION
## Summary

- Fix JET.jl static analysis issue in `symmetry()` function by adding explicit check for iterator returning `nothing` (line 1257)
- Add JET.jl to test dependencies with version compatibility for 0.9-0.11
- Add new JET static analysis testset to verify type stability

## Details

### Type stability fix in `symmetry()`

JET.jl identified a potential type instability in the `symmetry()` function where `iterate(subtrees)` could return `nothing`, and then destructuring it would fail. While the code has a guard checking `order(t) > 2` before reaching this line (which ensures at least one subtree exists), JET cannot prove this invariant.

The fix adds an explicit check:
```julia
first_iter = iterate(subtrees)
first_iter === nothing && error("Unexpected: tree with order >= 3 has no subtrees")
previous_subtree, state = first_iter
```

This maintains the same runtime behavior while satisfying JET's static analysis.

### JET static analysis tests

Added tests that verify type stability for:
- Core functions: `order`, `symmetry`, `density`, `α`, `β`
- Iterators: `RootedTreeIterator`, `SubtreeIterator`
- Colored tree operations: `order`, `symmetry`, `density`, `BicoloredRootedTreeIterator`

## Test plan

- [x] All existing tests pass (`Pkg.test()` shows 580,752 passing tests)
- [x] New JET tests pass
- [x] JET.report_call shows no issues for key functions

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)