### PR TITLE
Add JET.jl static analysis tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -10,6 +11,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 [compat]
 Aqua = "0.8"
 ExplicitImports = "1"
+JET = "0.9, 0.10, 0.11"
 LaTeXStrings = "1.2"
 Plots = "1.39"
 StaticArrays = "1.3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using LaTeXStrings: @L_str
 
 using Aqua: Aqua
 using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_imports
+using JET: @test_opt
 
 @testset "RootedTrees" begin
     @testset "RootedTree" begin
@@ -1896,5 +1897,46 @@ using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_import
     @testset "ExplicitImports" begin
         @test isnothing(check_no_implicit_imports(RootedTrees))
         @test isnothing(check_no_stale_explicit_imports(RootedTrees))
+    end
+
+    @testset "JET static analysis" begin
+        # Test core type-stable functions with JET's optimization analysis.
+        # We use `target_modules=(RootedTrees,)` to focus on issues within
+        # this package, ignoring any issues from dependencies.
+        #
+        # Note: Some functions like `symmetry` use recursion which JET cannot
+        # fully analyze for optimization, but they are still type-stable
+        # as verified by the @inferred tests throughout this file.
+
+        # Core tree construction and properties
+        t = rootedtree([1, 2, 3, 2])
+        @test_opt target_modules = (RootedTrees,) order(t)
+        @test_opt target_modules = (RootedTrees,) γ(t)
+        @test_opt target_modules = (RootedTrees,) hash(t)
+
+        # Iterator construction
+        @test_opt target_modules = (RootedTrees,) RootedTreeIterator(4)
+        iter = RootedTreeIterator(4)
+        @test_opt target_modules = (RootedTrees,) iterate(iter)
+
+        # ColoredRootedTree construction
+        ct = rootedtree([1, 2, 3], Bool[true, false, true])
+        @test_opt target_modules = (RootedTrees,) order(ct)
+        @test_opt target_modules = (RootedTrees,) γ(ct)
+        @test_opt target_modules = (RootedTrees,) hash(ct)
+
+        # RungeKuttaMethod construction
+        A = [0 0; 1//2 0]
+        b = [0, 1]
+        c = [0, 1//2]
+        @test_opt target_modules = (RootedTrees,) RungeKuttaMethod(A, b, c)
+
+        # RosenbrockMethod construction
+        @test_opt target_modules = (RootedTrees,) RosenbrockMethod([1//2;;], [0 0; 1 0], [1//2, 1//2])
+
+        # SubtreeIterator
+        @test_opt target_modules = (RootedTrees,) RootedTrees.SubtreeIterator(t)
+        subtrees = RootedTrees.SubtreeIterator(t)
+        @test_opt target_modules = (RootedTrees,) iterate(subtrees)
     end
 end # @testset "RootedTrees"


### PR DESCRIPTION
## Summary

This PR adds JET.jl-based static analysis testing to the RootedTrees.jl test suite, complementing the existing `@inferred` tests.

**Changes:**
- Add JET as a test dependency in test/Project.toml (supporting versions 0.9, 0.10, 0.11)
- Add `@test_opt` tests for core type-stable functions

**JET tests cover:**
- Core tree construction and properties (`order`, `density`, `hash`)
- Iterator construction (`RootedTreeIterator`, `SubtreeIterator`)
- `ColoredRootedTree` operations
- `RungeKuttaMethod` and `RosenbrockMethod` construction

## Background

JET analysis was run on the package and found:
1. **No type errors** - `report_package("RootedTrees")` completed with 0 errors
2. Some expected recursion optimization limitations in functions like `symmetry` (inherent to tree-traversal algorithms)
3. False positives for impossible code paths (e.g., iterating over empty iterators where the code ensures non-empty iterators)

The package is already well-typed - these tests document and maintain that quality.

## Test plan

- [x] Run `Pkg.test()` - all 580,761 tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)