### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,8 +1,0 @@
-# Use SciML style: https://github.com/SciML/SciMLStyle
-style = "sciml"
-
-# Python style alignment. See https://github.com/domluna/JuliaFormatter.jl/pull/732.
-yas_style_nesting = true
-
-# Align struct fields for better readability of large struct definitions
-align_struct_field = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
+      - 'master'
       - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-suggestions-on-pr.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,26 +4,30 @@ import Pkg
 # Fix for https://github.com/trixi-framework/Trixi.jl/issues/668
 # to allow building the docs locally
 if (get(ENV, "CI", nothing) != "true") &&
-   (get(ENV, "JULIA_DOC_DEFAULT_ENVIRONMENT", nothing) != "true")
+        (get(ENV, "JULIA_DOC_DEFAULT_ENVIRONMENT", nothing) != "true")
     push!(LOAD_PATH, dirname(@__DIR__))
 end
 
 using RootedTrees
 
 # Define module-wide setups such that the respective modules are available in doctests
-DocMeta.setdocmeta!(RootedTrees,
-                    :DocTestSetup, :(using RootedTrees); recursive = true)
+DocMeta.setdocmeta!(
+    RootedTrees,
+    :DocTestSetup, :(using RootedTrees); recursive = true
+)
 
 # Copy some files from the top level directory to the docs and modify them
 # as necessary
 open(joinpath(@__DIR__, "src", "license.md"), "w") do io
     # Point to source license file
-    println(io,
-            """
-    ```@meta
-    EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/LICENSE.md"
-    ```
-    """)
+    println(
+        io,
+        """
+        ```@meta
+        EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/LICENSE.md"
+        ```
+        """
+    )
     # Write the modified contents
     println(io, "# License")
     println(io, "")
@@ -35,12 +39,14 @@ end
 
 open(joinpath(@__DIR__, "src", "contributing.md"), "w") do io
     # Point to source license file
-    println(io,
-            """
-    ```@meta
-    EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/CONTRIBUTING.md"
-    ```
-    """)
+    println(
+        io,
+        """
+        ```@meta
+        EditURL = "https://github.com/SciML/RootedTrees.jl/blob/main/CONTRIBUTING.md"
+        ```
+        """
+    )
     # Write the modified contents
     println(io, "# Contributing")
     println(io, "")
@@ -51,30 +57,40 @@ open(joinpath(@__DIR__, "src", "contributing.md"), "w") do io
 end
 
 # Make documentation
-makedocs(modules = [RootedTrees],
-         sitename = "RootedTrees.jl",
-         format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
-                                  canonical = "https://SciML.github.io/RootedTrees.jl/stable",
-                                  ansicolor = true),
-         # Explicitly specify documentation structure
-         pages = [
-             "Home" => "index.md",
-             "Introduction" => "introduction.md",
-             "Tutorials" => [
-                 "tutorials/basics.md",
-                 "tutorials/RK_order_conditions.md",
-                 "tutorials/ARK_order_conditions.md",
-                 "tutorials/Rosenbrock_order_conditions.md"
-             ],
-             # "Benchmarks" => "benchmarks.md",
-             "API reference" => "api_reference.md",
-             "Contributing" => "contributing.md",
-             "License" => "license.md"
-         ])
+makedocs(
+    modules = [RootedTrees],
+    sitename = "RootedTrees.jl",
+    format = Documenter.HTML(
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        canonical = "https://SciML.github.io/RootedTrees.jl/stable",
+        ansicolor = true
+    ),
+    # Explicitly specify documentation structure
+    pages = [
+        "Home" => "index.md",
+        "Introduction" => "introduction.md",
+        "Tutorials" => [
+            "tutorials/basics.md",
+            "tutorials/RK_order_conditions.md",
+            "tutorials/ARK_order_conditions.md",
+            "tutorials/Rosenbrock_order_conditions.md",
+        ],
+        # "Benchmarks" => "benchmarks.md",
+        "API reference" => "api_reference.md",
+        "Contributing" => "contributing.md",
+        "License" => "license.md",
+    ]
+)
 
-deploydocs(repo = "github.com/SciML/RootedTrees.jl",
-           devbranch = "main",
-           # Only push previews if all the relevant environment variables are non-empty.
-           push_preview = all(!isempty,
-                              (get(ENV, "GITHUB_TOKEN", ""),
-                               get(ENV, "DOCUMENTER_KEY", ""))))
+deploydocs(
+    repo = "github.com/SciML/RootedTrees.jl",
+    devbranch = "main",
+    # Only push previews if all the relevant environment variables are non-empty.
+    push_preview = all(
+        !isempty,
+        (
+            get(ENV, "GITHUB_TOKEN", ""),
+            get(ENV, "DOCUMENTER_KEY", ""),
+        )
+    )
+)

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -11,10 +11,10 @@ using Preferences: @set_preferences!, @load_preference
 using RecipesBase: RecipesBase
 
 export RootedTree, rootedtree, rootedtree!, RootedTreeIterator,
-       ColoredRootedTree, BicoloredRootedTree, BicoloredRootedTreeIterator
+    ColoredRootedTree, BicoloredRootedTree, BicoloredRootedTreeIterator
 
 export butcher_representation, elementary_differential_latexstring,
-       elementary_weight_latexstring
+    elementary_weight_latexstring
 
 export α, β, γ, density, σ, symmetry, order, root_color
 
@@ -27,9 +27,9 @@ export count_trees
 export subtrees, SubtreeIterator
 
 export partition_forest,
-       PartitionForestIterator,
-       partition_skeleton,
-       all_partitions, PartitionIterator
+    PartitionForestIterator,
+    partition_skeleton,
+    all_partitions, PartitionIterator
 
 export all_splittings, SplittingIterator
 
@@ -57,10 +57,14 @@ struct RootedTree{T <: Integer, V <: AbstractVector{T}} <: AbstractRootedTree
     level_sequence::V
     iscanonical::Bool
 
-    function RootedTree(level_sequence::V,
-                        iscanonical::Bool = false) where {T <: Integer,
-                                                          V <: AbstractVector{T}}
-        new{T, V}(level_sequence, iscanonical)
+    function RootedTree(
+            level_sequence::V,
+            iscanonical::Bool = false
+        ) where {
+            T <: Integer,
+            V <: AbstractVector{T},
+        }
+        return new{T, V}(level_sequence, iscanonical)
     end
 end
 
@@ -82,7 +86,7 @@ function rootedtree(level_sequence::AbstractVector)
         throw(ArgumentError("The level sequence $level_sequence does not represent a rooted tree."))
     end
 
-    canonical_representation(RootedTree(level_sequence))
+    return canonical_representation(RootedTree(level_sequence))
 end
 
 # check whether the level sequence represents a rooted tree
@@ -93,8 +97,10 @@ end
 
     root = first(level_sequence)
     prev = root
-    for level in view(level_sequence,
-             (firstindex(level_sequence) + 1):lastindex(level_sequence))
+    for level in view(
+            level_sequence,
+            (firstindex(level_sequence) + 1):lastindex(level_sequence)
+        )
         if (level <= root) || (level > prev + 1)
             return false
         end
@@ -123,7 +129,7 @@ may be modified in this process. See also [`rootedtree`](@ref).
   [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
 """
 function rootedtree!(level_sequence::AbstractVector)
-    canonical_representation!(RootedTree(level_sequence))
+    return canonical_representation!(RootedTree(level_sequence))
 end
 
 iscanonical(t::RootedTree) = t.iscanonical
@@ -187,8 +193,10 @@ of `t_dst` is set. Use with caution!
     This function is considered to be an internal implementation detail and
     will not necessarily be stable.
 """
-@inline function unsafe_copyto!(t_dst::RootedTree, dst_offset,
-                                t_src::RootedTree, src_offset, N)
+@inline function unsafe_copyto!(
+        t_dst::RootedTree, dst_offset,
+        t_src::RootedTree, src_offset, N
+    )
     copyto!(t_dst.level_sequence, dst_offset, t_src.level_sequence, src_offset, N)
     return t_dst
 end
@@ -220,7 +228,7 @@ end
 
 function Base.show(io::IO, t::RootedTree{T}) where {T}
     printing_style = @load_preference("printing_style", "sequence")
-    if printing_style == "butcher"
+    return if printing_style == "butcher"
         print(io, butcher_representation(t))
     else
         print(io, "RootedTree{", T, "}: ")
@@ -243,7 +251,7 @@ function set_printing_style(style::String)
         throw(ArgumentError("Invalid printing style: \"$(style)\""))
     end
 
-    @set_preferences!("printing_style"=>style)
+    return @set_preferences!("printing_style" => style)
 end
 
 # comparison
@@ -366,7 +374,7 @@ i.e., the one with lexicographically biggest level sequence.
 See also [`canonical_representation!`](@ref).
 """
 function canonical_representation(t::AbstractRootedTree)
-    canonical_representation!(copy(t))
+    return canonical_representation!(copy(t))
 end
 
 # A very simple implementation of `canonical_representation!` could read as
@@ -418,8 +426,10 @@ function canonical_representation!(t::RootedTree, buffer = similar(t.level_seque
 
         # We found a complete subtree
         subtree = RootedTree(view(t.level_sequence, subtree_root_index:subtree_last_index))
-        canonical_representation!(subtree,
-                                  view(buffer, subtree_root_index:subtree_last_index))
+        canonical_representation!(
+            subtree,
+            view(buffer, subtree_root_index:subtree_last_index)
+        )
 
         subtree_root_index = subtree_last_index + 1
         number_of_subtrees += 1
@@ -442,29 +452,47 @@ function canonical_representation!(t::RootedTree, buffer = similar(t.level_seque
             subtree1_last_index = 0
             subtree2_last_index = 0
             while subtree1_root_index <= subtree_last_index_to_sort
-                subtree1_last_index = _subtree_last_index(subtree1_root_index,
-                                                          t.level_sequence)
+                subtree1_last_index = _subtree_last_index(
+                    subtree1_root_index,
+                    t.level_sequence
+                )
                 subtree2_last_index = subtree1_last_index
 
                 # Search the next complete subtree
                 subtree1_last_index == subtree_last_index_to_sort && break
 
                 subtree2_root_index = subtree1_last_index + 1
-                subtree2_last_index = _subtree_last_index(subtree2_root_index,
-                                                          t.level_sequence)
+                subtree2_last_index = _subtree_last_index(
+                    subtree2_root_index,
+                    t.level_sequence
+                )
 
                 # Swap the subtrees if they are not sorted correctly
-                subtree1 = RootedTree(view(t.level_sequence,
-                                           subtree1_root_index:subtree1_last_index))
-                subtree2 = RootedTree(view(t.level_sequence,
-                                           subtree2_root_index:subtree2_last_index))
+                subtree1 = RootedTree(
+                    view(
+                        t.level_sequence,
+                        subtree1_root_index:subtree1_last_index
+                    )
+                )
+                subtree2 = RootedTree(
+                    view(
+                        t.level_sequence,
+                        subtree2_root_index:subtree2_last_index
+                    )
+                )
                 if isless(subtree1, subtree2)
-                    copyto!(buffer, 1, t.level_sequence, subtree1_root_index,
-                            order(subtree1) + order(subtree2))
-                    copyto!(t.level_sequence, subtree1_root_index, buffer,
-                            order(subtree1) + 1, order(subtree2))
-                    copyto!(t.level_sequence, subtree1_root_index + order(subtree2), buffer,
-                            1, order(subtree1))
+                    copyto!(
+                        buffer, 1, t.level_sequence, subtree1_root_index,
+                        order(subtree1) + order(subtree2)
+                    )
+                    copyto!(
+                        t.level_sequence, subtree1_root_index, buffer,
+                        order(subtree1) + 1, order(subtree2)
+                    )
+                    copyto!(
+                        t.level_sequence, subtree1_root_index + order(subtree2), buffer,
+                        1, order(subtree1)
+                    )
                     # `subtree1_root_index` will be updated below using `subtree1_last_index`.
                     # Thus, we need to adapt this variable here.
                     subtree1_last_index = subtree1_root_index + order(subtree2) - 1
@@ -481,7 +509,7 @@ function canonical_representation!(t::RootedTree, buffer = similar(t.level_seque
         end
     end
 
-    RootedTree(t.level_sequence, true)
+    return RootedTree(t.level_sequence, true)
 end
 
 @inline function _subtree_last_index(subtree_root_index, level_sequence)
@@ -509,7 +537,7 @@ function canonical_representation!(t::RootedTree{Int, Vector{Int}})
     else
         buffer = similar(t.level_sequence)
     end
-    canonical_representation!(t, buffer)
+    return canonical_representation!(t, buffer)
 end
 
 """
@@ -539,7 +567,7 @@ set to `root`.
 """
 function normalize_root!(t::AbstractRootedTree, root = one(eltype(t.level_sequence)))
     t.level_sequence .+= root - first(t.level_sequence)
-    t
+    return t
 end
 
 """
@@ -554,7 +582,7 @@ struct RootedTreeIterator{T <: Integer}
     t::RootedTree{T, Vector{T}}
 
     function RootedTreeIterator(order::T) where {T <: Integer}
-        new{T}(order, RootedTree(Vector{T}(one(T):order), true))
+        return new{T}(order, RootedTree(Vector{T}(one(T):order), true))
     end
 end
 
@@ -563,7 +591,7 @@ Base.eltype(::Type{RootedTreeIterator{T}}) where {T} = RootedTree{T, Vector{T}}
 
 @inline function Base.iterate(iter::RootedTreeIterator{T}) where {T}
     iter.t.level_sequence[:] = one(T):(iter.order)
-    (iter.t, iter.order <= 0)
+    return (iter.t, iter.order <= 0)
 end
 
 @inline function Base.iterate(iter::RootedTreeIterator{T}, state) where {T}
@@ -590,7 +618,7 @@ end
         iter.t.level_sequence[i] = iter.t.level_sequence[i - (p - q)]
     end
 
-    (iter.t, false)
+    return (iter.t, false)
 end
 
 """
@@ -605,7 +633,7 @@ function count_trees(order)
     for _ in RootedTreeIterator(order)
         num += 1
     end
-    num
+    return num
 end
 
 # subtrees
@@ -628,7 +656,7 @@ end
 
 @inline function Base.iterate(subtrees::SubtreeIterator{<:RootedTree})
     subtree_root_index = firstindex(subtrees.t.level_sequence) + 1
-    iterate(subtrees, subtree_root_index)
+    return iterate(subtrees, subtree_root_index)
 end
 
 @inline function Base.iterate(subtrees::SubtreeIterator{<:RootedTree}, subtree_root_index)
@@ -641,9 +669,11 @@ end
 
     # find the next complete subtree
     subtree_last_index = _subtree_last_index(subtree_root_index, level_sequence)
-    subtree = RootedTree(view(level_sequence, subtree_root_index:subtree_last_index),
-                         # if t is in canonical representation, its subtrees are, too
-                         iscanonical(subtrees.t))
+    subtree = RootedTree(
+        view(level_sequence, subtree_root_index:subtree_last_index),
+        # if t is in canonical representation, its subtrees are, too
+        iscanonical(subtrees.t)
+    )
 
     return (subtree, subtree_last_index + 1)
 end
@@ -671,7 +701,7 @@ function subtrees(t::RootedTree)
         end
         i += 1
     end
-    push!(subtr, RootedTree(t.level_sequence[start:end]))
+    return push!(subtr, RootedTree(t.level_sequence[start:end]))
 end
 
 # partitions
@@ -725,7 +755,7 @@ function partition_forest!(forest, level_sequence, edge_set)
 
         edge_to_remove = findlast(==(false), edge_set)
     end
-    push!(forest, rootedtree!(copy(level_sequence)))
+    return push!(forest, rootedtree!(copy(level_sequence)))
 end
 
 """
@@ -757,7 +787,7 @@ end
 function PartitionForestIterator(t::AbstractRootedTree, edge_set)
     t_iter = copy(t)
     t_temp = copy(t)
-    PartitionForestIterator(t_iter, t_temp, copy(edge_set))
+    return PartitionForestIterator(t_iter, t_temp, copy(edge_set))
 end
 
 Base.IteratorSize(::Type{<:PartitionForestIterator}) = Base.HasLength()
@@ -765,7 +795,7 @@ Base.length(forest::PartitionForestIterator) = count(==(false), forest.edge_set)
 Base.eltype(::Type{PartitionForestIterator{Tree}}) where {Tree} = Tree
 
 @inline function Base.iterate(forest::PartitionForestIterator)
-    iterate(forest, lastindex(forest.edge_set))
+    return iterate(forest, lastindex(forest.edge_set))
 end
 
 @inline function Base.iterate(forest::PartitionForestIterator, search_start)
@@ -880,7 +910,7 @@ function partition_skeleton!(skeleton::AbstractRootedTree, edge_set)
 
     # The level sequence `level_sequence` will not automatically be a canonical
     # representation.
-    canonical_representation!(skeleton)
+    return canonical_representation!(skeleton)
 end
 
 """
@@ -905,7 +935,7 @@ function all_partitions(t::RootedTree)
     forests = [partition_forest(t, edge_set)]
     skeletons = [partition_skeleton(t, edge_set)]
 
-    for edge_set_value in 1:(2 ^ length(edge_set) - 1)
+    for edge_set_value in 1:(2^length(edge_set) - 1)
         binary_digits!(edge_set, edge_set_value)
         push!(forests, partition_forest(t, edge_set))
         push!(skeletons, partition_skeleton(t, edge_set))
@@ -923,7 +953,7 @@ function binary_digits!(digits::Vector{Bool}, n::Int)
         digits[i] = n & bit > 0
         bit = bit << 1
     end
-    digits
+    return digits
 end
 
 """
@@ -963,8 +993,10 @@ function PartitionIterator(t::AbstractRootedTree)
     t_forest = similar(t)
     t_temp_forest = similar(t)
     forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
-    PartitionIterator{typeof(t), typeof(skeleton)}(t, forest, skeleton, edge_set,
-                                                   edge_set_tmp)
+    return PartitionIterator{typeof(t), typeof(skeleton)}(
+        t, forest, skeleton, edge_set,
+        edge_set_tmp
+    )
 end
 
 # Allocate global buffer for `PartitionIterator` for each thread
@@ -1005,20 +1037,24 @@ function PartitionIterator(t::RootedTree{Int, Vector{Int}})
     t_forest = RootedTree(buffer_forest_t, true)
     t_temp_forest = RootedTree(level_sequence, true)
     forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
-    PartitionIterator{typeof(t), RootedTree{Int, Vector{Int}}}(t, forest, skeleton,
-                                                               edge_set, edge_set_tmp)
+    return PartitionIterator{typeof(t), RootedTree{Int, Vector{Int}}}(
+        t, forest, skeleton,
+        edge_set, edge_set_tmp
+    )
 end
 
 Base.IteratorSize(::Type{<:PartitionIterator}) = Base.HasLength()
 Base.length(partitions::PartitionIterator) = 2^length(partitions.edge_set)
-function Base.eltype(::Type{PartitionIterator{TreeInput, TreeOutput}}) where {TreeInput,
-                                                                              TreeOutput}
-    Tuple{PartitionForestIterator{TreeOutput}, TreeOutput}
+function Base.eltype(::Type{PartitionIterator{TreeInput, TreeOutput}}) where {
+        TreeInput,
+        TreeOutput,
+    }
+    return Tuple{PartitionForestIterator{TreeOutput}, TreeOutput}
 end
 
 @inline function Base.iterate(partitions::PartitionIterator)
     edge_set_value = 0
-    iterate(partitions, edge_set_value)
+    return iterate(partitions, edge_set_value)
 end
 
 @inline function Base.iterate(partitions::PartitionIterator, edge_set_value)
@@ -1051,13 +1087,19 @@ end
     unsafe_resize!(forest.t_temp, order(t))
     copy!(forest.t_temp, t)
 
-    ((forest, skeleton), edge_set_value + 1)
+    return ((forest, skeleton), edge_set_value + 1)
 end
 
 # necessary for simple and convenient use since the iterates may be modified
-function Base.collect(partitions::PartitionIterator{TreeInput,
-                                                    TreeOutput}) where {TreeInput,
-                                                                        TreeOutput}
+function Base.collect(
+        partitions::PartitionIterator{
+            TreeInput,
+            TreeOutput,
+        }
+    ) where {
+        TreeInput,
+        TreeOutput,
+    }
     iterates = Vector{Tuple{Vector{TreeOutput}, TreeOutput}}()
     sizehint!(iterates, length(partitions))
     for (forest, skeleton) in partitions
@@ -1090,7 +1132,7 @@ function all_splittings(t::RootedTree)
     forests = Vector{Vector{RootedTree{T, Vector{T}}}}()
     subtrees = Vector{RootedTree{T, Vector{T}}}() # ordered subtrees
 
-    for node_set_value in 0:(2 ^ order(t) - 1)
+    for node_set_value in 0:(2^order(t) - 1)
         binary_digits!(node_set, node_set_value)
 
         # Check that if a node is removed then all of its descendants are removed
@@ -1150,7 +1192,7 @@ struct SplittingIterator{T <: RootedTree}
 
     function SplittingIterator(t::T) where {T <: RootedTree}
         node_set = zeros(Bool, order(t))
-        new{T}(t, node_set, 2^order(t) - 1)
+        return new{T}(t, node_set, 2^order(t) - 1)
     end
 end
 
@@ -1159,7 +1201,7 @@ Base.eltype(::Type{SplittingIterator{T}}) where {T} = Tuple{Vector{T}, T}
 
 @inline function Base.iterate(splittings::SplittingIterator)
     node_set_value = 0
-    iterate(splittings, node_set_value)
+    return iterate(splittings, node_set_value)
 end
 
 @inline function Base.iterate(splittings::SplittingIterator, node_set_value)
@@ -1265,7 +1307,7 @@ function symmetry(t::AbstractRootedTree)
             num_same_subtrees += 1
         else
             result *= factorial(num_same_subtrees) *
-                      symmetry(previous_subtree)^num_same_subtrees
+                symmetry(previous_subtree)^num_same_subtrees
             num_same_subtrees = 1
         end
 
@@ -1298,7 +1340,7 @@ function density(t::AbstractRootedTree)
     for subtree in SubtreeIterator(t)
         result *= density(subtree)
     end
-    result
+    return result
 end
 
 const γ = density
@@ -1314,7 +1356,7 @@ Reference: Section 302 of
   John Wiley & Sons, 2008.
 """
 function α(t::AbstractRootedTree)
-    div(factorial(order(t)), σ(t) * γ(t))
+    return div(factorial(order(t)), σ(t) * γ(t))
 end
 
 """
@@ -1328,7 +1370,7 @@ Reference: Section 302 of
   John Wiley & Sons, 2008.
 """
 function β(t::AbstractRootedTree)
-    div(factorial(order(t)), σ(t))
+    return div(factorial(order(t)), σ(t))
 end
 
 # additional representation and construction methods
@@ -1348,7 +1390,7 @@ Reference: Section 301 of
 function Base.:∘(t1::RootedTree, t2::RootedTree)
     offset = first(t1.level_sequence) - first(t2.level_sequence) + 1
     level_sequence = vcat(t1.level_sequence, t2.level_sequence .+ offset)
-    rootedtree(level_sequence)
+    return rootedtree(level_sequence)
 end
 
 """
@@ -1365,8 +1407,10 @@ Reference: Section 301 of
   Numerical methods for ordinary differential equations.
   John Wiley & Sons, 2016.
 """
-function butcher_product!(t::RootedTree,
-                          t1::RootedTree, t2::RootedTree)
+function butcher_product!(
+        t::RootedTree,
+        t1::RootedTree, t2::RootedTree
+    )
     offset = first(t1.level_sequence) - first(t2.level_sequence) + 1
 
     unsafe_resize!(t, order(t1) + order(t2))
@@ -1520,7 +1564,7 @@ function elementary_weight_latexstring(t::RootedTree)
     indices = vcat(indices, idx)
     push!(substrings, substring)
 
-    pushfirst!(substrings, "\\sum_{$(join(indices,", "))}b_{$(first_index)}")
+    pushfirst!(substrings, "\\sum_{$(join(indices, ", "))}b_{$(first_index)}")
     return latexstring(join(substrings))
 end
 
@@ -1577,26 +1621,44 @@ include("time_integration_methods.jl")
 
 function __init__()
     # canonical_representation!
-    Threads.resize_nthreads!(CANONICAL_REPRESENTATION_BUFFER,
-                             Vector{Int}(undef, BUFFER_LENGTH))
+    Threads.resize_nthreads!(
+        CANONICAL_REPRESENTATION_BUFFER,
+        Vector{Int}(undef, BUFFER_LENGTH)
+    )
 
     # PartitionIterator
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T,
-                             Vector{Int}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_T_COLORS,
-                             Vector{Bool}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE,
-                             Vector{Int}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_FOREST_COLOR_SEQUENCE,
-                             Vector{Bool}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON,
-                             Vector{Int}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_SKELETON_COLORS,
-                             Vector{Bool}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET,
-                             Vector{Bool}(undef, BUFFER_LENGTH))
-    Threads.resize_nthreads!(PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
-                             Vector{Bool}(undef, BUFFER_LENGTH))
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_FOREST_T,
+        Vector{Int}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_FOREST_T_COLORS,
+        Vector{Bool}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_FOREST_LEVEL_SEQUENCE,
+        Vector{Int}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_FOREST_COLOR_SEQUENCE,
+        Vector{Bool}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_SKELETON,
+        Vector{Int}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_SKELETON_COLORS,
+        Vector{Bool}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_EDGE_SET,
+        Vector{Bool}(undef, BUFFER_LENGTH)
+    )
+    Threads.resize_nthreads!(
+        PARTITION_ITERATOR_BUFFER_EDGE_SET_TMP,
+        Vector{Bool}(undef, BUFFER_LENGTH)
+    )
 
     return nothing
 end

--- a/src/colored_trees.jl
+++ b/src/colored_trees.jl
@@ -1,4 +1,3 @@
-
 """
     ColoredRootedTree(level_sequence, color_sequence, is_canonical::Bool=false)
 
@@ -23,16 +22,20 @@ See also [`BicoloredRootedTree`](@ref), [`rootedtree`](@ref).
   [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
 """
 struct ColoredRootedTree{T <: Integer, V <: AbstractVector{T}, C <: AbstractVector} <:
-       AbstractRootedTree
+    AbstractRootedTree
     level_sequence::V
     color_sequence::C
     iscanonical::Bool
 
-    function ColoredRootedTree(level_sequence::V, color_sequence::C,
-                               iscanonical::Bool = false) where {T <: Integer,
-                                                                 V <: AbstractVector{T},
-                                                                 C <: AbstractVector}
-        new{T, V, C}(level_sequence, color_sequence, iscanonical)
+    function ColoredRootedTree(
+            level_sequence::V, color_sequence::C,
+            iscanonical::Bool = false
+        ) where {
+            T <: Integer,
+            V <: AbstractVector{T},
+            C <: AbstractVector,
+        }
+        return new{T, V, C}(level_sequence, color_sequence, iscanonical)
     end
 end
 
@@ -43,10 +46,14 @@ Representation of bicolored rooted trees.
 
 See also [`ColoredRootedTree`](@ref), [`RootedTree`](@ref), [`rootedtree`](@ref).
 """
-const BicoloredRootedTree{T <: Integer, V <: AbstractVector{T},
-                          C <: AbstractVector{Bool}} = ColoredRootedTree{T,
-                                                                         V,
-                                                                         C}
+const BicoloredRootedTree{
+    T <: Integer, V <: AbstractVector{T},
+    C <: AbstractVector{Bool},
+} = ColoredRootedTree{
+    T,
+    V,
+    C,
+}
 
 """
     rootedtree(level_sequence, color_sequence)
@@ -71,7 +78,7 @@ function rootedtree(level_sequence::AbstractVector, color_sequence::AbstractVect
         throw(ArgumentError("The level sequence $level_sequence does not represent a rooted tree."))
     end
 
-    canonical_representation(ColoredRootedTree(level_sequence, color_sequence))
+    return canonical_representation(ColoredRootedTree(level_sequence, color_sequence))
 end
 
 """
@@ -89,21 +96,21 @@ and a `color_sequence` which may be modified in this process. See also
   [DOI: 10.1137/0209055](https://doi.org/10.1137/0209055)
 """
 function rootedtree!(level_sequence::AbstractVector, color_sequence::AbstractVector)
-    canonical_representation!(ColoredRootedTree(level_sequence, color_sequence))
+    return canonical_representation!(ColoredRootedTree(level_sequence, color_sequence))
 end
 
 iscanonical(t::ColoredRootedTree) = t.iscanonical
 #TODO: Validate rooted tree in constructor?
 
 function Base.copy(t::ColoredRootedTree)
-    ColoredRootedTree(copy(t.level_sequence), copy(t.color_sequence), t.iscanonical)
+    return ColoredRootedTree(copy(t.level_sequence), copy(t.color_sequence), t.iscanonical)
 end
 function Base.similar(t::ColoredRootedTree)
-    ColoredRootedTree(similar(t.level_sequence), similar(t.color_sequence), true)
+    return ColoredRootedTree(similar(t.level_sequence), similar(t.color_sequence), true)
 end
 Base.isempty(t::ColoredRootedTree) = isempty(t.level_sequence)
 function Base.empty(t::ColoredRootedTree)
-    ColoredRootedTree(empty(t.level_sequence), empty(t.color_sequence), iscanonical(t))
+    return ColoredRootedTree(empty(t.level_sequence), empty(t.color_sequence), iscanonical(t))
 end
 
 @inline function Base.copy!(t_dst::ColoredRootedTree, t_src::ColoredRootedTree)
@@ -134,8 +141,10 @@ end
 end
 
 # Internal interface
-@inline function unsafe_copyto!(t_dst::ColoredRootedTree, dst_offset,
-                                t_src::ColoredRootedTree, src_offset, N)
+@inline function unsafe_copyto!(
+        t_dst::ColoredRootedTree, dst_offset,
+        t_src::ColoredRootedTree, src_offset, N
+    )
     copyto!(t_dst.level_sequence, dst_offset, t_src.level_sequence, src_offset, N)
     copyto!(t_dst.color_sequence, dst_offset, t_src.color_sequence, src_offset, N)
     return t_dst
@@ -151,7 +160,7 @@ function Base.show(io::IO, t::ColoredRootedTree{T}) where {T}
     # end
     # print(io, "]")
     print(io, "ColoredRootedTree{", T, "}: ")
-    show(io, (t.level_sequence, t.color_sequence))
+    return show(io, (t.level_sequence, t.color_sequence))
 end
 
 # comparison
@@ -204,8 +213,10 @@ function Base.:(==)(t1::ColoredRootedTree, t2::ColoredRootedTree)
     end
 
     root1_minus_root2 = first(t1.level_sequence) - first(t2.level_sequence)
-    for (e1, c1, e2, c2) in zip(t1.level_sequence, t1.color_sequence, t2.level_sequence,
-            t2.color_sequence)
+    for (e1, c1, e2, c2) in zip(
+            t1.level_sequence, t1.color_sequence, t2.level_sequence,
+            t2.color_sequence
+        )
         v1 = e1
         v2 = e2 + root1_minus_root2
         (v1 == v2 && c1 == c2) || return false
@@ -288,9 +299,11 @@ end
 # non-allocating sorting algorithm instead - although bubble sort is slower in
 # general when comparing the complexity with quicksort etc., it will be faster
 # here since we can avoid allocations.
-function canonical_representation!(t::ColoredRootedTree,
-                                   buffer_level = similar(t.level_sequence),
-                                   buffer_color = similar(t.color_sequence))
+function canonical_representation!(
+        t::ColoredRootedTree,
+        buffer_level = similar(t.level_sequence),
+        buffer_color = similar(t.color_sequence)
+    )
     # Since we use a recursive implementation, it is useful to exit early for
     # small trees. If there are at most 3 vertices in a valid rooted tree, its
     # level sequence must already be in canonical representation. However, the
@@ -311,11 +324,15 @@ function canonical_representation!(t::ColoredRootedTree,
 
         # We found a complete subtree
         idx_subtree = subtree_root_index:subtree_last_index
-        subtree = ColoredRootedTree(view(t.level_sequence, idx_subtree),
-                                    view(t.color_sequence, idx_subtree))
-        canonical_representation!(subtree,
-                                  view(buffer_level, idx_subtree),
-                                  view(buffer_color, idx_subtree))
+        subtree = ColoredRootedTree(
+            view(t.level_sequence, idx_subtree),
+            view(t.color_sequence, idx_subtree)
+        )
+        canonical_representation!(
+            subtree,
+            view(buffer_level, idx_subtree),
+            view(buffer_color, idx_subtree)
+        )
 
         subtree_root_index = subtree_last_index + 1
         number_of_subtrees += 1
@@ -338,38 +355,58 @@ function canonical_representation!(t::ColoredRootedTree,
             subtree1_last_index = 0
             subtree2_last_index = 0
             while subtree1_root_index <= subtree_last_index_to_sort
-                subtree1_last_index = _subtree_last_index(subtree1_root_index,
-                                                          t.level_sequence)
+                subtree1_last_index = _subtree_last_index(
+                    subtree1_root_index,
+                    t.level_sequence
+                )
                 subtree2_last_index = subtree1_last_index
 
                 # Search the next complete subtree
                 subtree1_last_index == subtree_last_index_to_sort && break
 
                 subtree2_root_index = subtree1_last_index + 1
-                subtree2_last_index = _subtree_last_index(subtree2_root_index,
-                                                          t.level_sequence)
+                subtree2_last_index = _subtree_last_index(
+                    subtree2_root_index,
+                    t.level_sequence
+                )
 
                 # Swap the subtrees if they are not sorted correctly
                 subtree1_idx = subtree1_root_index:subtree1_last_index
-                subtree1 = ColoredRootedTree(view(t.level_sequence, subtree1_idx),
-                                             view(t.color_sequence, subtree1_idx))
+                subtree1 = ColoredRootedTree(
+                    view(t.level_sequence, subtree1_idx),
+                    view(t.color_sequence, subtree1_idx)
+                )
                 subtree2_idx = subtree2_root_index:subtree2_last_index
-                subtree2 = ColoredRootedTree(view(t.level_sequence, subtree2_idx),
-                                             view(t.color_sequence, subtree2_idx))
+                subtree2 = ColoredRootedTree(
+                    view(t.level_sequence, subtree2_idx),
+                    view(t.color_sequence, subtree2_idx)
+                )
                 if isless(subtree1, subtree2)
-                    copyto!(buffer_level, 1, t.level_sequence, subtree1_root_index,
-                            order(subtree1) + order(subtree2))
-                    copyto!(t.level_sequence, subtree1_root_index, buffer_level,
-                            order(subtree1) + 1, order(subtree2))
-                    copyto!(t.level_sequence, subtree1_root_index + order(subtree2),
-                            buffer_level, 1, order(subtree1))
+                    copyto!(
+                        buffer_level, 1, t.level_sequence, subtree1_root_index,
+                        order(subtree1) + order(subtree2)
+                    )
+                    copyto!(
+                        t.level_sequence, subtree1_root_index, buffer_level,
+                        order(subtree1) + 1, order(subtree2)
+                    )
+                    copyto!(
+                        t.level_sequence, subtree1_root_index + order(subtree2),
+                        buffer_level, 1, order(subtree1)
+                    )
 
-                    copyto!(buffer_color, 1, t.color_sequence, subtree1_root_index,
-                            order(subtree1) + order(subtree2))
-                    copyto!(t.color_sequence, subtree1_root_index, buffer_color,
-                            order(subtree1) + 1, order(subtree2))
-                    copyto!(t.color_sequence, subtree1_root_index + order(subtree2),
-                            buffer_color, 1, order(subtree1))
+                    copyto!(
+                        buffer_color, 1, t.color_sequence, subtree1_root_index,
+                        order(subtree1) + order(subtree2)
+                    )
+                    copyto!(
+                        t.color_sequence, subtree1_root_index, buffer_color,
+                        order(subtree1) + 1, order(subtree2)
+                    )
+                    copyto!(
+                        t.color_sequence, subtree1_root_index + order(subtree2),
+                        buffer_color, 1, order(subtree1)
+                    )
 
                     # `subtree1_root_index` will be updated below using `subtree1_last_index`.
                     # Thus, we need to adapt this variable here.
@@ -387,7 +424,7 @@ function canonical_representation!(t::ColoredRootedTree,
         end
     end
 
-    ColoredRootedTree(t.level_sequence, t.color_sequence, true)
+    return ColoredRootedTree(t.level_sequence, t.color_sequence, true)
 end
 
 """
@@ -406,20 +443,20 @@ struct BicoloredRootedTreeIterator{T <: Integer}
         iter = RootedTreeIterator(order)
         number_of_colors = convert(T, 2)^order
         t = ColoredRootedTree(iter.t.level_sequence, zeros(Bool, order), true)
-        new{T}(number_of_colors, iter, t)
+        return new{T}(number_of_colors, iter, t)
     end
 end
 
 Base.IteratorSize(::Type{<:BicoloredRootedTreeIterator}) = Base.SizeUnknown()
 function Base.eltype(::Type{BicoloredRootedTreeIterator{T}}) where {T}
-    BicoloredRootedTree{T, Vector{T}, Vector{Bool}}
+    return BicoloredRootedTree{T, Vector{T}, Vector{Bool}}
 end
 
 @inline function Base.iterate(iter::BicoloredRootedTreeIterator)
     _, inner_state = iterate(iter.iter)
     color_id = 0
     binary_digits!(iter.t.color_sequence, color_id)
-    (iter.t, (inner_state, color_id + 1))
+    return (iter.t, (inner_state, color_id + 1))
 end
 
 @inline function Base.iterate(iter::BicoloredRootedTreeIterator, state)
@@ -458,11 +495,13 @@ end
 # subtrees
 @inline function Base.iterate(subtrees::SubtreeIterator{<:ColoredRootedTree})
     subtree_root_index = firstindex(subtrees.t.level_sequence) + 1
-    iterate(subtrees, subtree_root_index)
+    return iterate(subtrees, subtree_root_index)
 end
 
-@inline function Base.iterate(subtrees::SubtreeIterator{<:ColoredRootedTree},
-                              subtree_root_index)
+@inline function Base.iterate(
+        subtrees::SubtreeIterator{<:ColoredRootedTree},
+        subtree_root_index
+    )
     level_sequence = subtrees.t.level_sequence
     color_sequence = subtrees.t.color_sequence
 
@@ -473,10 +512,12 @@ end
 
     # find the next complete subtree
     subtree_last_index = _subtree_last_index(subtree_root_index, level_sequence)
-    subtree = ColoredRootedTree(view(level_sequence, subtree_root_index:subtree_last_index),
-                                view(color_sequence, subtree_root_index:subtree_last_index),
-                                # if t is in canonical representation, its subtrees are, too
-                                iscanonical(subtrees.t))
+    subtree = ColoredRootedTree(
+        view(level_sequence, subtree_root_index:subtree_last_index),
+        view(color_sequence, subtree_root_index:subtree_last_index),
+        # if t is in canonical representation, its subtrees are, too
+        iscanonical(subtrees.t)
+    )
 
     return (subtree, subtree_last_index + 1)
 end
@@ -487,9 +528,11 @@ end
 Returns a vector of all subtrees of `t`.
 """
 function subtrees(t::ColoredRootedTree)
-    subtr = ColoredRootedTree{eltype(t.level_sequence),
-                              Vector{eltype(t.level_sequence)},
-                              Vector{eltype(t.color_sequence)}}[]
+    subtr = ColoredRootedTree{
+        eltype(t.level_sequence),
+        Vector{eltype(t.level_sequence)},
+        Vector{eltype(t.color_sequence)},
+    }[]
 
     if length(t.level_sequence) < 2
         return subtr
@@ -499,15 +542,21 @@ function subtrees(t::ColoredRootedTree)
     i = 3
     while i <= length(t.level_sequence)
         if t.level_sequence[i] <= t.level_sequence[start]
-            push!(subtr,
-                  ColoredRootedTree(t.level_sequence[start:(i - 1)],
-                                    t.color_sequence[start:(i - 1)]))
+            push!(
+                subtr,
+                ColoredRootedTree(
+                    t.level_sequence[start:(i - 1)],
+                    t.color_sequence[start:(i - 1)]
+                )
+            )
             start = i
         end
         i += 1
     end
-    push!(subtr,
-          ColoredRootedTree(t.level_sequence[start:end], t.color_sequence[start:end]))
+    return push!(
+        subtr,
+        ColoredRootedTree(t.level_sequence[start:end], t.color_sequence[start:end])
+    )
 end
 
 # partitions
@@ -550,11 +599,13 @@ function PartitionIterator(t::ColoredRootedTree{Int, Vector{Int}, Vector{Bool}})
     t_forest = ColoredRootedTree(buffer_forest_t, buffer_forest_t_colors, true)
     t_temp_forest = ColoredRootedTree(level_sequence, color_sequence, true)
     forest = PartitionForestIterator(t_forest, t_temp_forest, edge_set_tmp)
-    PartitionIterator{typeof(t), ColoredRootedTree{Int, Vector{Int}, Vector{Bool}}}(t,
-                                                                                    forest,
-                                                                                    skeleton,
-                                                                                    edge_set,
-                                                                                    edge_set_tmp)
+    return PartitionIterator{typeof(t), ColoredRootedTree{Int, Vector{Int}, Vector{Bool}}}(
+        t,
+        forest,
+        skeleton,
+        edge_set,
+        edge_set_tmp
+    )
 end
 
 # TODO: ColoredRootedTree. splittings
@@ -566,11 +617,13 @@ function Base.:∘(t1::ColoredRootedTree, t2::ColoredRootedTree)
     offset = first(t1.level_sequence) - first(t2.level_sequence) + 1
     level_sequence = vcat(t1.level_sequence, t2.level_sequence .+ offset)
     color_sequence = vcat(t1.color_sequence, t2.color_sequence)
-    rootedtree(level_sequence, color_sequence)
+    return rootedtree(level_sequence, color_sequence)
 end
 
-function butcher_product!(t::ColoredRootedTree,
-                          t1::ColoredRootedTree, t2::ColoredRootedTree)
+function butcher_product!(
+        t::ColoredRootedTree,
+        t1::ColoredRootedTree, t2::ColoredRootedTree
+    )
     offset = first(t1.level_sequence) - first(t2.level_sequence) + 1
 
     unsafe_resize!(t, order(t1) + order(t2))
@@ -594,8 +647,10 @@ function butcher_product!(t::ColoredRootedTree,
     return t
 end
 
-function butcher_representation(t::ColoredRootedTree, normalize::Bool = true;
-                                colormap = _colormap_butcher_representation(t))
+function butcher_representation(
+        t::ColoredRootedTree, normalize::Bool = true;
+        colormap = _colormap_butcher_representation(t)
+    )
     if order(t) == 0
         return "∅"
     elseif order(t) == 1

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -1,4 +1,3 @@
-
 """
     latexify(t::Union{RootedTree, BicoloredRootedTree})
 
@@ -107,5 +106,5 @@ function set_latexify_style(style::String)
         throw(ArgumentError("Invalid printing style: \"$(style)\""))
     end
 
-    @set_preferences!("latexify_style"=>style)
+    return @set_preferences!("latexify_style" => style)
 end

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -1,4 +1,3 @@
-
 RecipesBase.@recipe function plot(t::AbstractRootedTree)
     # Compute x and y coordinates recursively
     width = 2.0
@@ -42,9 +41,11 @@ RecipesBase.@recipe function plot(t::AbstractRootedTree)
     x, y
 end
 
-function _plot_coordinates(t::AbstractRootedTree,
-                           x_root::T, y_root::T,
-                           width::T, height::T) where {T}
+function _plot_coordinates(
+        t::AbstractRootedTree,
+        x_root::T, y_root::T,
+        width::T, height::T
+    ) where {T}
     # Indicate a new line series by `NaN`
     nan = convert(T, NaN)
 
@@ -73,8 +74,10 @@ function _plot_coordinates(t::AbstractRootedTree,
         push!(x, nan, x_root, x_child)
         push!(y, nan, y_root, y_child)
         x_recursive,
-        y_recursive = _plot_coordinates(subtr[idx],
-                                        x_child, y_child, width / 3, height)
+            y_recursive = _plot_coordinates(
+            subtr[idx],
+            x_child, y_child, width / 3, height
+        )
         append!(x, x_recursive)
         append!(y, y_recursive)
     end
@@ -146,10 +149,12 @@ RecipesBase.@recipe function plot(t::ColoredRootedTree)
     x, y
 end
 
-function _plot_coordinates(t::ColoredRootedTree,
-                           x_root::T, y_root::T,
-                           width::T, height::T,
-                           colormap) where {T}
+function _plot_coordinates(
+        t::ColoredRootedTree,
+        x_root::T, y_root::T,
+        width::T, height::T,
+        colormap
+    ) where {T}
     # Initialize vectors of return values
     x = Vector{Vector{T}}()
     y = Vector{Vector{T}}()
@@ -214,10 +219,12 @@ function _plot_coordinates(t::ColoredRootedTree,
         push!(y, [y_root, y_child])
         push!(colors, [color_root, colormap[first(subtr[idx].color_sequence)]])
         x_recursive, y_recursive,
-        colors_recursive = _plot_coordinates(subtr[idx],
-                                             x_child, y_child,
-                                             width / 3, height,
-                                             colormap)
+            colors_recursive = _plot_coordinates(
+            subtr[idx],
+            x_child, y_child,
+            width / 3, height,
+            colormap
+        )
         append!(x, x_recursive)
         append!(y, y_recursive)
         append!(colors, colors_recursive)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -119,43 +119,93 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    Base.precompile(Tuple{typeof(residual_order_condition),
-                          RootedTree{Int64, Vector{Int64}},
-                          RungeKuttaMethod{Rational{Int64}, Matrix{Rational{Int64}},
-                                           Vector{Rational{Int64}}}})   # time: 0.18134941
-    Base.precompile(Tuple{typeof(residual_order_condition),
-                          BicoloredRootedTree{Int64, Vector{Int64}, Vector{Bool}},
-                          AdditiveRungeKuttaMethod{Rational{Int64},
-                                                   Vector{RungeKuttaMethod{Rational{Int64},
-                                                                           Matrix{Rational{Int64}},
-                                                                           Vector{Rational{Int64}}}}}})   # time: 0.16824293
+    Base.precompile(
+        Tuple{
+            typeof(residual_order_condition),
+            RootedTree{Int64, Vector{Int64}},
+            RungeKuttaMethod{
+                Rational{Int64}, Matrix{Rational{Int64}},
+                Vector{Rational{Int64}},
+            },
+        }
+    )   # time: 0.18134941
+    Base.precompile(
+        Tuple{
+            typeof(residual_order_condition),
+            BicoloredRootedTree{Int64, Vector{Int64}, Vector{Bool}},
+            AdditiveRungeKuttaMethod{
+                Rational{Int64},
+                Vector{
+                    RungeKuttaMethod{
+                        Rational{Int64},
+                        Matrix{Rational{Int64}},
+                        Vector{Rational{Int64}},
+                    },
+                },
+            },
+        }
+    )   # time: 0.16824293
     Base.precompile(Tuple{typeof(rootedtree), Vector{Int64}})   # time: 0.087751105
-    Base.precompile(Tuple{typeof(residual_order_condition),
-                          RootedTree{Int64, Vector{Int64}},
-                          RosenbrockMethod{Float64, Matrix{Float64}, Vector{Float64}}})   # time: 0.07817012
-    Base.precompile(Tuple{Type{RungeKuttaMethod}, Matrix{Rational{Int64}},
-                          Vector{Rational{Int64}}})   # time: 0.075997345
-    Base.precompile(Tuple{Type{AdditiveRungeKuttaMethod}, Vector{Matrix{Rational{Int64}}},
-                          Vector{Vector{Rational{Int64}}}})   # time: 0.05049169
-    Base.precompile(Tuple{typeof(iterate),
-                          SplittingIterator{RootedTree{Int64, Vector{Int64}}}})   # time: 0.044273302
-    Base.precompile(Tuple{Type{RosenbrockMethod}, Matrix{Float64}, Matrix{Float64},
-                          Vector{Float64}})   # time: 0.016924093
+    Base.precompile(
+        Tuple{
+            typeof(residual_order_condition),
+            RootedTree{Int64, Vector{Int64}},
+            RosenbrockMethod{Float64, Matrix{Float64}, Vector{Float64}},
+        }
+    )   # time: 0.07817012
+    Base.precompile(
+        Tuple{
+            Type{RungeKuttaMethod}, Matrix{Rational{Int64}},
+            Vector{Rational{Int64}},
+        }
+    )   # time: 0.075997345
+    Base.precompile(
+        Tuple{
+            Type{AdditiveRungeKuttaMethod}, Vector{Matrix{Rational{Int64}}},
+            Vector{Vector{Rational{Int64}}},
+        }
+    )   # time: 0.05049169
+    Base.precompile(
+        Tuple{
+            typeof(iterate),
+            SplittingIterator{RootedTree{Int64, Vector{Int64}}},
+        }
+    )   # time: 0.044273302
+    Base.precompile(
+        Tuple{
+            Type{RosenbrockMethod}, Matrix{Float64}, Matrix{Float64},
+            Vector{Float64},
+        }
+    )   # time: 0.016924093
     Base.precompile(Tuple{typeof(butcher_representation), RootedTree{Int64, Vector{Int64}}})   # time: 0.014338499
-    Base.precompile(Tuple{typeof(iterate), BicoloredRootedTreeIterator{Int64},
-                          Tuple{Bool, Int64}})   # time: 0.014068822
-    Base.precompile(Tuple{typeof(symmetry),
-                          BicoloredRootedTree{Int64, Vector{Int64}, Vector{Bool}}})   # time: 0.008579416
+    Base.precompile(
+        Tuple{
+            typeof(iterate), BicoloredRootedTreeIterator{Int64},
+            Tuple{Bool, Int64},
+        }
+    )   # time: 0.014068822
+    Base.precompile(
+        Tuple{
+            typeof(symmetry),
+            BicoloredRootedTree{Int64, Vector{Int64}, Vector{Bool}},
+        }
+    )   # time: 0.008579416
     Base.precompile(Tuple{typeof(symmetry), RootedTree{Int64, Vector{Int64}}})   # time: 0.007220166
-    Base.precompile(Tuple{typeof(iterate),
-                          PartitionIterator{RootedTree{Int64, Vector{Int64}},
-                                            RootedTree{Int64, Vector{Int64}}}})   # time: 0.006673861
+    Base.precompile(
+        Tuple{
+            typeof(iterate),
+            PartitionIterator{
+                RootedTree{Int64, Vector{Int64}},
+                RootedTree{Int64, Vector{Int64}},
+            },
+        }
+    )   # time: 0.006673861
     Base.precompile(Tuple{Type{BicoloredRootedTreeIterator}, Int64})   # time: 0.003071257
     Base.precompile(Tuple{Type{PartitionIterator}, RootedTree{Int64, Vector{Int64}}})   # time: 0.002802794
     Base.precompile(Tuple{typeof(iterate), RootedTreeIterator{Int64}, Bool})   # time: 0.002423941
     Base.precompile(Tuple{Type{RootedTreeIterator}, Int64})   # time: 0.002368873
     Base.precompile(Tuple{typeof(iterate), RootedTreeIterator{Int64}})   # time: 0.002200462
-    Base.precompile(Tuple{typeof(iterate), BicoloredRootedTreeIterator{Int64}})   # time: 0.001368852
+    return Base.precompile(Tuple{typeof(iterate), BicoloredRootedTreeIterator{Int64}})   # time: 0.001368852
 end
 
 _precompile_()

--- a/src/time_integration_methods.jl
+++ b/src/time_integration_methods.jl
@@ -1,4 +1,3 @@
-
 abstract type AbstractTimeIntegrationMethod end
 
 """
@@ -9,14 +8,16 @@ If `c` is not provided, the usual "row sum" requirement of consistency with
 autonomous problems is applied.
 """
 struct RungeKuttaMethod{T, MatT <: AbstractMatrix{T}, VecT <: AbstractVector{T}} <:
-       AbstractTimeIntegrationMethod
+    AbstractTimeIntegrationMethod
     A::MatT
     b::VecT
     c::VecT
 end
 
-function RungeKuttaMethod(A::AbstractMatrix, b::AbstractVector,
-                          c::AbstractVector = vec(sum(A, dims = 2)))
+function RungeKuttaMethod(
+        A::AbstractMatrix, b::AbstractVector,
+        c::AbstractVector = vec(sum(A, dims = 2))
+    )
     T = promote_type(eltype(A), eltype(b), eltype(c))
     _A = T.(A)
     _b = T.(b)
@@ -28,7 +29,7 @@ Base.eltype(rk::RungeKuttaMethod{T}) where {T} = T
 
 function Base.show(io::IO, rk::RungeKuttaMethod)
     print(io, "RungeKuttaMethod{", eltype(rk), "}")
-    if get(io, :compact, false)
+    return if get(io, :compact, false)
         print(io, "(")
         show(io, rk.A)
         print(io, ", ")
@@ -60,13 +61,15 @@ Reference: Section 312 of
   John Wiley & Sons, 2008.
 """
 function elementary_weight(t::RootedTree, rk::RungeKuttaMethod)
-    dot(rk.b, derivative_weight(t, rk))
+    return dot(rk.b, derivative_weight(t, rk))
 end
 
 # TODO: Deprecate also this method?
-function elementary_weight(t::RootedTree, A::AbstractMatrix, b::AbstractVector,
-                           c::AbstractVector)
-    elementary_weight(t, RungeKuttaMethod(A, b, c))
+function elementary_weight(
+        t::RootedTree, A::AbstractMatrix, b::AbstractVector,
+        c::AbstractVector
+    )
+    return elementary_weight(t, RungeKuttaMethod(A, b, c))
 end
 
 """
@@ -97,10 +100,14 @@ function derivative_weight(t::RootedTree, rk::RungeKuttaMethod)
 end
 
 # TODO: Deprecations introduced in v2
-@deprecate derivative_weight(t::RootedTree, A, b, c) derivative_weight(t,
-                                                                       RungeKuttaMethod(A,
-                                                                                        b,
-                                                                                        c))
+@deprecate derivative_weight(t::RootedTree, A, b, c) derivative_weight(
+    t,
+    RungeKuttaMethod(
+        A,
+        b,
+        c
+    )
+)
 
 """
     residual_order_condition(t::RootedTree, rk::RungeKuttaMethod)
@@ -122,14 +129,18 @@ function residual_order_condition(t::RootedTree, rk::RungeKuttaMethod)
     invγ = 1 // γ(t)
     invσ = 1 // σ(t)
 
-    (ew - invγ) * invσ
+    return (ew - invγ) * invσ
 end
 
 # TODO: Deprecations introduced in v2
-@deprecate residual_order_condition(t::RootedTree, A, b, c) residual_order_condition(t,
-                                                                                     RungeKuttaMethod(A,
-                                                                                                      b,
-                                                                                                      c))
+@deprecate residual_order_condition(t::RootedTree, A, b, c) residual_order_condition(
+    t,
+    RungeKuttaMethod(
+        A,
+        b,
+        c
+    )
+)
 
 """
     AdditiveRungeKuttaMethod(rks)
@@ -169,7 +180,7 @@ methods, which are applied to partitioned problems of the form
   [DOI: 10.1137/S0036142995292128](https://doi.org/10.1137/S0036142995292128)
 """
 struct AdditiveRungeKuttaMethod{T, RKs <: AbstractVector{<:RungeKuttaMethod{T}}} <:
-       AbstractTimeIntegrationMethod
+    AbstractTimeIntegrationMethod
     rks::RKs
 end
 
@@ -178,12 +189,12 @@ function AdditiveRungeKuttaMethod(rks) # if not all RK methods use the same elty
     As = map(rk -> T.(rk.A), rks)
     bs = map(rk -> T.(rk.b), rks)
     cs = map(rk -> T.(rk.c), rks)
-    AdditiveRungeKuttaMethod(As, bs, cs)
+    return AdditiveRungeKuttaMethod(As, bs, cs)
 end
 
 function AdditiveRungeKuttaMethod(As, bs, cs = map(A -> vec(sum(A, dims = 2)), As))
     rks = map(RungeKuttaMethod, As, bs, cs)
-    AdditiveRungeKuttaMethod(rks)
+    return AdditiveRungeKuttaMethod(rks)
 end
 
 Base.eltype(ark::AdditiveRungeKuttaMethod{T}) where {T} = T
@@ -194,6 +205,7 @@ function Base.show(io::IO, ark::AdditiveRungeKuttaMethod)
         print(io, idx, ". ")
         show(io, rk)
     end
+    return
 end
 
 # Colored trees are used for order conditions of additive Runge-Kutta methods.
@@ -287,7 +299,7 @@ function residual_order_condition(t::ColoredRootedTree, ark::AdditiveRungeKuttaM
     ew = elementary_weight(t, ark)
     T = typeof(ew)
 
-    (ew - one(T) / γ(t)) / σ(t)
+    return (ew - one(T) / γ(t)) / σ(t)
 end
 
 """
@@ -306,16 +318,18 @@ autonomous problems is applied.
   Section IV.7
 """
 struct RosenbrockMethod{T, MatT <: AbstractMatrix{T}, VecT <: AbstractVector{T}} <:
-       AbstractTimeIntegrationMethod
+    AbstractTimeIntegrationMethod
     γ::MatT
     A::MatT
     b::VecT
     c::VecT
 end
 
-function RosenbrockMethod(γ::AbstractMatrix, A::AbstractMatrix,
-                          b::AbstractVector,
-                          c::AbstractVector = vec(sum(A, dims = 2)))
+function RosenbrockMethod(
+        γ::AbstractMatrix, A::AbstractMatrix,
+        b::AbstractVector,
+        c::AbstractVector = vec(sum(A, dims = 2))
+    )
     T = promote_type(eltype(γ), eltype(A), eltype(b), eltype(c))
     _γ = T.(γ)
     _A = T.(A)
@@ -328,7 +342,7 @@ Base.eltype(ros::RosenbrockMethod{T}) where {T} = T
 
 function Base.show(io::IO, ros::RosenbrockMethod)
     print(io, "RosenbrockMethod{", eltype(ros), "}")
-    if get(io, :compact, false)
+    return if get(io, :compact, false)
         print(io, "(")
         show(io, ros.γ)
         print(io, ", ")
@@ -358,7 +372,7 @@ Compute the elementary weight Φ(`t`) of the [`RosenbrockMethod`](@ref) `ros`
 for a rooted tree `t`.
 """
 function elementary_weight(t::RootedTree, ros::RosenbrockMethod)
-    dot(ros.b, derivative_weight(t, ros))
+    return dot(ros.b, derivative_weight(t, ros))
 end
 
 """
@@ -415,5 +429,5 @@ function residual_order_condition(t::RootedTree, ros::RosenbrockMethod)
     ew = elementary_weight(t, ros)
     T = typeof(ew)
 
-    (ew - one(T) / γ(t)) / σ(t)
+    return (ew - one(T) / γ(t)) / σ(t)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,16 +24,20 @@ using JET: @test_opt
         end
 
         @testset "comparisons etc." begin
-            trees = (rootedtree([1, 2, 3]),
-                     rootedtree([1, 2, 3]),
-                     rootedtree([1, 2, 2]),
-                     rootedtree([1, 2, 3, 3]),
-                     rootedtree(Int[]))
-            trees_shifted = (rootedtree([1, 2, 3]),
-                             rootedtree([2, 3, 4]),
-                             rootedtree([1, 2, 2]),
-                             rootedtree([1, 2, 3, 3]),
-                             rootedtree(Int[]))
+            trees = (
+                rootedtree([1, 2, 3]),
+                rootedtree([1, 2, 3]),
+                rootedtree([1, 2, 2]),
+                rootedtree([1, 2, 3, 3]),
+                rootedtree(Int[]),
+            )
+            trees_shifted = (
+                rootedtree([1, 2, 3]),
+                rootedtree([2, 3, 4]),
+                rootedtree([1, 2, 2]),
+                rootedtree([1, 2, 3, 3]),
+                rootedtree(Int[]),
+            )
 
             for (t1, t2, t3, t4, t5) in (trees, trees_shifted)
                 @test t1 == t1
@@ -385,9 +389,9 @@ using JET: @test_opt
             @test t5 == t_result
             @test butcher_representation(t5) == "[τ³]"
             @test RootedTrees.subtrees(t5) ==
-                  [rootedtree([2]), rootedtree([2]), rootedtree([2])]
+                [rootedtree([2]), rootedtree([2]), rootedtree([2])]
             @test elementary_differential_latexstring(t5) ==
-                  L"$f^{\prime\prime\prime}(f, f, f)$"
+                L"$f^{\prime\prime\prime}(f, f, f)$"
             @test elementary_weight_latexstring(t5) == L"$\sum_{d}b_{d}c_{d}^{3}$"
 
             t6 = rootedtree([1, 2, 2, 3])
@@ -407,9 +411,9 @@ using JET: @test_opt
             @test butcher_representation(t6) == "[[τ]τ]"
             @test RootedTrees.subtrees(t6) == [rootedtree([2, 3]), rootedtree([2])]
             @test elementary_differential_latexstring(t6) ==
-                  L"$f^{\prime\prime}(f^{\prime}f, f)$"
+                L"$f^{\prime\prime}(f^{\prime}f, f)$"
             @test elementary_weight_latexstring(t6) ==
-                  L"$\sum_{d, e}b_{d}a_{d,e}c_{e}c_{d}$"
+                L"$\sum_{d, e}b_{d}a_{d,e}c_{e}c_{d}$"
 
             t7 = rootedtree([1, 2, 3, 3])
             @test order(t7) == 4
@@ -422,7 +426,7 @@ using JET: @test_opt
             @test t7 == t_result
             @test butcher_representation(t7) == "[[τ²]]"
             @test elementary_differential_latexstring(t7) ==
-                  L"$f^{\prime}f^{\prime\prime}(f, f)$"
+                L"$f^{\prime}f^{\prime\prime}(f, f)$"
             @test elementary_weight_latexstring(t7) == L"$\sum_{d, e}b_{d}a_{d,e}c_{e}^{2}$"
 
             t8 = rootedtree([1, 2, 3, 4])
@@ -436,9 +440,9 @@ using JET: @test_opt
             @test t8 == t_result
             @test butcher_representation(t8) == "[[[τ]]]"
             @test elementary_differential_latexstring(t8) ==
-                  L"$f^{\prime}f^{\prime}f^{\prime}f$"
+                L"$f^{\prime}f^{\prime}f^{\prime}f$"
             @test elementary_weight_latexstring(t8) ==
-                  L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}$"
+                L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}$"
 
             t9 = rootedtree([1, 2, 2, 2, 2])
             @test order(t9) == 5
@@ -469,9 +473,9 @@ using JET: @test_opt
             @test t10 == t_result
             @test butcher_representation(t10) == "[[τ]τ²]"
             @test elementary_differential_latexstring(t10) ==
-                  L"$f^{\prime\prime\prime}(f^{\prime}f, f, f)$"
+                L"$f^{\prime\prime\prime}(f^{\prime}f, f, f)$"
             @test elementary_weight_latexstring(t10) ==
-                  L"$\sum_{d, e}b_{d}a_{d,e}c_{e}c_{d}^{2}$"
+                L"$\sum_{d, e}b_{d}a_{d,e}c_{e}c_{d}^{2}$"
 
             t11 = rootedtree([1, 2, 2, 3, 3])
             @test order(t11) == 5
@@ -487,9 +491,9 @@ using JET: @test_opt
             @test t11 == t_result
             @test butcher_representation(t11) == "[[τ²]τ]"
             @test elementary_differential_latexstring(t11) ==
-                  L"$f^{\prime\prime}(f^{\prime\prime}(f, f), f)$"
+                L"$f^{\prime\prime}(f^{\prime\prime}(f, f), f)$"
             @test elementary_weight_latexstring(t11) ==
-                  L"$\sum_{d, e}b_{d}a_{d,e}c_{e}^{2}c_{d}$"
+                L"$\sum_{d, e}b_{d}a_{d,e}c_{e}^{2}c_{d}$"
 
             t12 = rootedtree([1, 2, 2, 3, 4])
             @test order(t12) == 5
@@ -506,9 +510,9 @@ using JET: @test_opt
             @test t12 == t_result
             @test butcher_representation(t12) == "[[[τ]]τ]"
             @test elementary_differential_latexstring(t12) ==
-                  L"$f^{\prime\prime}(f^{\prime}f^{\prime}f, f)$"
+                L"$f^{\prime\prime}(f^{\prime}f^{\prime}f, f)$"
             @test elementary_weight_latexstring(t12) ==
-                  L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}c_{d}$"
+                L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}c_{d}$"
 
             t13 = rootedtree([1, 2, 3, 2, 3])
             @test order(t13) == 5
@@ -522,9 +526,9 @@ using JET: @test_opt
             @test t13 == t_result
             @test butcher_representation(t13) == "[[τ][τ]]"
             @test elementary_differential_latexstring(t13) ==
-                  L"$f^{\prime\prime}(f^{\prime}f, f^{\prime}f)$"
+                L"$f^{\prime\prime}(f^{\prime}f, f^{\prime}f)$"
             @test elementary_weight_latexstring(t13) ==
-                  L"$\sum_{d, e}b_{d}(a_{d,e}c_{e})^{2}$"
+                L"$\sum_{d, e}b_{d}(a_{d,e}c_{e})^{2}$"
 
             t14 = rootedtree([1, 2, 3, 3, 3])
             @test order(t14) == 5
@@ -538,9 +542,9 @@ using JET: @test_opt
             @test t14 == t_result
             @test butcher_representation(t14) == "[[τ³]]"
             @test elementary_differential_latexstring(t14) ==
-                  L"$f^{\prime}f^{\prime\prime\prime}(f, f, f)$"
+                L"$f^{\prime}f^{\prime\prime\prime}(f, f, f)$"
             @test elementary_weight_latexstring(t14) ==
-                  L"$\sum_{d, e}b_{d}a_{d,e}c_{e}^{3}$"
+                L"$\sum_{d, e}b_{d}a_{d,e}c_{e}^{3}$"
 
             t15 = rootedtree([1, 2, 3, 3, 4])
             @test order(t15) == 5
@@ -554,9 +558,9 @@ using JET: @test_opt
             @test t15 == t_result
             @test butcher_representation(t15) == "[[[τ]τ]]"
             @test elementary_differential_latexstring(t15) ==
-                  L"$f^{\prime}f^{\prime\prime}(f^{\prime}f, f)$"
+                L"$f^{\prime}f^{\prime\prime}(f^{\prime}f, f)$"
             @test elementary_weight_latexstring(t15) ==
-                  L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}c_{e}$"
+                L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}c_{e}$"
 
             t16 = rootedtree([1, 2, 3, 4, 4])
             @test order(t16) == 5
@@ -570,9 +574,9 @@ using JET: @test_opt
             @test t16 == t_result
             @test butcher_representation(t16) == "[[[τ²]]]"
             @test elementary_differential_latexstring(t16) ==
-                  L"$f^{\prime}f^{\prime}f^{\prime\prime}(f, f)$"
+                L"$f^{\prime}f^{\prime}f^{\prime\prime}(f, f)$"
             @test elementary_weight_latexstring(t16) ==
-                  L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}^{2}$"
+                L"$\sum_{d, e, f}b_{d}a_{d,e}a_{e,f}c_{f}^{2}$"
 
             t17 = rootedtree([1, 2, 3, 4, 5])
             @test order(t17) == 5
@@ -586,19 +590,19 @@ using JET: @test_opt
             @test t17 == t_result
             @test butcher_representation(t17) == "[[[[τ]]]]"
             @test elementary_differential_latexstring(t17) ==
-                  L"$f^{\prime}f^{\prime}f^{\prime}f^{\prime}f$"
+                L"$f^{\prime}f^{\prime}f^{\prime}f^{\prime}f$"
             @test elementary_weight_latexstring(t17) ==
-                  L"$\sum_{d, e, f, g}b_{d}a_{d,e}a_{e,f}a_{f,g}c_{g}$"
+                L"$\sum_{d, e, f, g}b_{d}a_{d,e}a_{e,f}a_{f,g}c_{g}$"
 
             # test elementary_weight_latexstring which needs more than 23 indices
 
             t18 = rootedtree(collect(1:25))
             @test elementary_weight_latexstring(t18) ==
-                  L"$\sum_{d1, e1, f1, g1, h1, i1, j1, k1, l1, m1, n1, o1, p1, q1, r1, s1, t1, u1, v1, w1, x1, y1, z1, d2}b_{d1}a_{d1,e1}a_{e1,f1}a_{f1,g1}a_{g1,h1}a_{h1,i1}a_{i1,j1}a_{j1,k1}a_{k1,l1}a_{l1,m1}a_{m1,n1}a_{n1,o1}a_{o1,p1}a_{p1,q1}a_{q1,r1}a_{r1,s1}a_{s1,t1}a_{t1,u1}a_{u1,v1}a_{v1,w1}a_{w1,x1}a_{x1,y1}a_{y1,z1}a_{z1,d2}c_{d2}$"
+                L"$\sum_{d1, e1, f1, g1, h1, i1, j1, k1, l1, m1, n1, o1, p1, q1, r1, s1, t1, u1, v1, w1, x1, y1, z1, d2}b_{d1}a_{d1,e1}a_{e1,f1}a_{f1,g1}a_{g1,h1}a_{h1,i1}a_{i1,j1}a_{j1,k1}a_{k1,l1}a_{l1,m1}a_{m1,n1}a_{n1,o1}a_{o1,p1}a_{p1,q1}a_{q1,r1}a_{r1,s1}a_{s1,t1}a_{t1,u1}a_{u1,v1}a_{v1,w1}a_{w1,x1}a_{x1,y1}a_{y1,z1}a_{z1,d2}c_{d2}$"
 
             t19 = rootedtree([1, 2, 2, 3, 2, 3])
             @test elementary_weight_latexstring(t19) ==
-                  L"$\sum_{d, e}b_{d}(a_{d,e}c_{e})^{2}c_{d}$"
+                L"$\sum_{d, e}b_{d}(a_{d,e}c_{e})^{2}c_{d}$"
 
             # test non-canonical representation
             level_sequence = [1, 2, 3, 2, 3, 4, 2, 3, 2, 3, 4, 5, 6, 2, 3, 4]
@@ -625,12 +629,14 @@ using JET: @test_opt
         @testset "partitions" begin
             let t = rootedtree([1, 2, 3, 4, 3])
                 edge_set = [true, true, false, false]
-                reference_forest = [rootedtree([1, 2, 3]),
+                reference_forest = [
+                    rootedtree([1, 2, 3]),
                     rootedtree([4]),
-                    rootedtree([3])]
+                    rootedtree([3]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -638,12 +644,14 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 4, 3])
                 edge_set = [false, true, true, false]
-                reference_forest = [rootedtree([3]),
+                reference_forest = [
+                    rootedtree([3]),
                     rootedtree([2, 3, 4]),
-                    rootedtree([1])]
+                    rootedtree([1]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -651,13 +659,15 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 4, 3])
                 edge_set = [false, true, false, false]
-                reference_forest = [rootedtree([4]),
+                reference_forest = [
+                    rootedtree([4]),
                     rootedtree([3]),
                     rootedtree([2, 3]),
-                    rootedtree([1])]
+                    rootedtree([1]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3, 3])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -665,12 +675,14 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 2, 2, 2])
                 edge_set = [false, false, true, true]
-                reference_forest = [rootedtree([2]),
+                reference_forest = [
                     rootedtree([2]),
-                    rootedtree([1, 2, 2])]
+                    rootedtree([2]),
+                    rootedtree([1, 2, 2]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -678,13 +690,15 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 2, 2])
                 edge_set = [false, false, false, true]
-                reference_forest = [rootedtree([3]),
+                reference_forest = [
+                    rootedtree([3]),
                     rootedtree([2]),
                     rootedtree([2]),
-                    rootedtree([1, 2])]
+                    rootedtree([1, 2]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3, 2])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -695,7 +709,7 @@ using JET: @test_opt
                 reference_forest = [rootedtree([1, 2, 3, 2, 2])]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -703,12 +717,14 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 2, 3])
                 edge_set = [true, true, false, false]
-                reference_forest = [rootedtree([3]),
+                reference_forest = [
+                    rootedtree([3]),
                     rootedtree([2]),
-                    rootedtree([1, 2, 3])]
+                    rootedtree([1, 2, 3]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -716,13 +732,15 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 2, 3])
                 edge_set = [false, true, false, false]
-                reference_forest = [rootedtree([2, 3]),
+                reference_forest = [
+                    rootedtree([2, 3]),
                     rootedtree([3]),
                     rootedtree([2]),
-                    rootedtree([1])]
+                    rootedtree([1]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2, 3])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -730,12 +748,14 @@ using JET: @test_opt
 
             let t = rootedtree([1, 2, 3, 3, 3])
                 edge_set = [false, true, true, false]
-                reference_forest = [rootedtree([3]),
+                reference_forest = [
+                    rootedtree([3]),
                     rootedtree([2, 3, 3]),
-                    rootedtree([1])]
+                    rootedtree([1]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -744,11 +764,13 @@ using JET: @test_opt
             # additional tests not included in the examples of the paper
             let t = rootedtree([1, 2, 3, 2, 3])
                 edge_set = [true, false, true, true]
-                reference_forest = [rootedtree([1, 2, 3, 2]),
-                    rootedtree([3])]
+                reference_forest = [
+                    rootedtree([1, 2, 3, 2]),
+                    rootedtree([3]),
+                ]
                 @test sort!(partition_forest(t, edge_set)) == sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -783,7 +805,7 @@ using JET: @test_opt
                 [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
                 [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
                 [rootedtree([1]), rootedtree([1]), rootedtree([1, 2])],
-                [rootedtree([1]), rootedtree([1]), rootedtree([1]), rootedtree([1])]
+                [rootedtree([1]), rootedtree([1]), rootedtree([1]), rootedtree([1])],
             ]
             reference_skeletons = [
                 rootedtree([1]),
@@ -793,7 +815,7 @@ using JET: @test_opt
                 rootedtree([1, 2, 2]),
                 rootedtree([1, 2, 3]),
                 rootedtree([1, 2, 3]),
-                rootedtree([1, 2, 3, 3])
+                rootedtree([1, 2, 3, 3]),
             ]
             for forest in reference_forests
                 sort!(forest)
@@ -820,7 +842,7 @@ using JET: @test_opt
                     for t in RootedTreeIterator(order)
                         forests, skeletons = all_partitions(t)
                         @test collect(zip(forests, skeletons)) ==
-                              collect(PartitionIterator(t))
+                            collect(PartitionIterator(t))
                     end
                 end
 
@@ -841,8 +863,14 @@ using JET: @test_opt
         @testset "splittings" begin
             t = rootedtree([1, 2, 3, 2, 2])
             splittings = all_splittings(t)
-            forests_and_subtrees = sort!(collect(zip(splittings.forests,
-                                                     splittings.subtrees)))
+            forests_and_subtrees = sort!(
+                collect(
+                    zip(
+                        splittings.forests,
+                        splittings.subtrees
+                    )
+                )
+            )
 
             reference_forests_and_subtrees = [
                 (empty([rootedtree([1])]), rootedtree([1, 2, 3, 2, 2])),
@@ -857,7 +885,7 @@ using JET: @test_opt
                 ([rootedtree([1]), rootedtree([1])], rootedtree([1, 2, 2])),
                 ([rootedtree([1]), rootedtree([1]), rootedtree([1])], rootedtree([1, 2])),
                 ([rootedtree([1, 2]), rootedtree([1]), rootedtree([1])], rootedtree([1])),
-                ([rootedtree([1, 2, 3, 2, 2])], rootedtree(Int[]))
+                ([rootedtree([1, 2, 3, 2, 2])], rootedtree(Int[])),
             ]
             sort!(reference_forests_and_subtrees)
 
@@ -882,32 +910,38 @@ using JET: @test_opt
         @testset "validate level sequence in constructor" begin
             @test_nowarn rootedtree([1, 2, 3, 4], Bool[0, 0, 0, 0])
             @test_throws DimensionMismatch rootedtree([1, 2, 3, 4, 5, 1], Bool[0, 0])
-            @test_throws ArgumentError rootedtree([1, 2, 3, 4, 5, 1],
-                                                  Bool[0, 0, 0, 0, 0, 0])
+            @test_throws ArgumentError rootedtree(
+                [1, 2, 3, 4, 5, 1],
+                Bool[0, 0, 0, 0, 0, 0]
+            )
             @test_throws ArgumentError rootedtree([1, 1], Bool[0, 0])
             @test_throws ArgumentError rootedtree([1, 3], Bool[0, 0])
             @test_throws ArgumentError rootedtree([1, 0], Bool[0, 0])
         end
 
         @testset "comparisons etc." begin
-            trees = (rootedtree([1, 2, 3], [1, 1, 1]),
-                     rootedtree([1, 2, 3], [1, 1, 1]),
-                     rootedtree([1, 2, 2], [1, 1, 1]),
-                     rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
-                     rootedtree(Int[], Int[]),
-                     rootedtree([1, 2, 3], [1, 1, 2]),
-                     rootedtree([1, 2, 3], [1, 2, 1]),
-                     rootedtree([1, 2, 3], [1, 2, 2]),
-                     rootedtree([1, 2, 2], [2, 2, 2]))
-            trees_shifted = (rootedtree([1, 2, 3], [1, 1, 1]),
-                             rootedtree([2, 3, 4], [1, 1, 1]),
-                             rootedtree([1, 2, 2], [1, 1, 1]),
-                             rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
-                             rootedtree(Int[], Int[]),
-                             rootedtree([1, 2, 3], [1, 1, 2]),
-                             rootedtree([0, 1, 2], [1, 2, 1]),
-                             rootedtree([2, 3, 4], [1, 2, 2]),
-                             rootedtree([1, 2, 2], [2, 2, 2]))
+            trees = (
+                rootedtree([1, 2, 3], [1, 1, 1]),
+                rootedtree([1, 2, 3], [1, 1, 1]),
+                rootedtree([1, 2, 2], [1, 1, 1]),
+                rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
+                rootedtree(Int[], Int[]),
+                rootedtree([1, 2, 3], [1, 1, 2]),
+                rootedtree([1, 2, 3], [1, 2, 1]),
+                rootedtree([1, 2, 3], [1, 2, 2]),
+                rootedtree([1, 2, 2], [2, 2, 2]),
+            )
+            trees_shifted = (
+                rootedtree([1, 2, 3], [1, 1, 1]),
+                rootedtree([2, 3, 4], [1, 1, 1]),
+                rootedtree([1, 2, 2], [1, 1, 1]),
+                rootedtree([1, 2, 3, 3], [1, 1, 1, 1]),
+                rootedtree(Int[], Int[]),
+                rootedtree([1, 2, 3], [1, 1, 2]),
+                rootedtree([0, 1, 2], [1, 2, 1]),
+                rootedtree([2, 3, 4], [1, 2, 2]),
+                rootedtree([1, 2, 2], [2, 2, 2]),
+            )
 
             for (t1, t2, t3, t4, t5, t6, t7, t8, t9) in (trees, trees_shifted)
                 @test t1 == t1
@@ -1007,8 +1041,10 @@ using JET: @test_opt
                     push!(hashes, new_hash)
                 end
             end
-            t = rootedtree([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 2],
-                           Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+            t = rootedtree(
+                [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 2],
+                Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+            )
             new_hash = @inferred hash(t)
             @test !(new_hash in hashes)
         end
@@ -1188,8 +1224,10 @@ using JET: @test_opt
                     @test latexify(t) == latex_string
                 end
 
-                let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
-                                   Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+                let t = rootedtree(
+                        [1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
+                        Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+                    )
                     latex_string = "\\rootedtree[.[o[.[o][.]][o[.]][o][.]][o]]"
                     @test latexify(t) == latex_string
                 end
@@ -1233,8 +1271,10 @@ using JET: @test_opt
                     @test latexify(t) == latex_string
                 end
 
-                let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
-                                   Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+                let t = rootedtree(
+                        [1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
+                        Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+                    )
                     latex_string = "[[[τ₁τ₀]₀[τ₀]₁τ₁τ₀]₁τ₁]₀"
                     @test latexify(t) == latex_string
                 end
@@ -1278,8 +1318,10 @@ using JET: @test_opt
                     @test latexify(t) == latex_string
                 end
 
-                let t = rootedtree([1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
-                                   Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+                let t = rootedtree(
+                        [1, 2, 3, 4, 4, 3, 4, 3, 3, 2],
+                        Bool[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+                    )
                     latex_string = "\\rootedtree[.[o[.[o][.]][o[.]][o][.]][o]]"
                     @test latexify(t) == latex_string
                 end
@@ -1319,12 +1361,14 @@ using JET: @test_opt
             # Example in Section 6.1
             let t = rootedtree([1, 2, 3, 3], Bool[0, 1, 0, 0])
                 edge_set = [false, true, false]
-                reference_forest = [rootedtree([3], Bool[0]),
+                reference_forest = [
+                    rootedtree([3], Bool[0]),
                     rootedtree([2, 3], Bool[1, 0]),
-                    rootedtree([1], Bool[0])]
+                    rootedtree([1], Bool[0]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3], Bool[0, 1, 0])
                 @test reference_skeleton == partition_skeleton(t, edge_set)
@@ -1333,74 +1377,84 @@ using JET: @test_opt
             # Other examples for single-colored trees
             let t = rootedtree([1, 2, 3, 4, 3], Bool[1, 1, 0, 1, 1])
                 edge_set = [true, true, false, false]
-                reference_forest = [rootedtree([1, 2, 3], Bool[1, 1, 0]),
+                reference_forest = [
+                    rootedtree([1, 2, 3], Bool[1, 1, 0]),
                     rootedtree([4], Bool[1]),
-                    rootedtree([3], Bool[1])]
+                    rootedtree([3], Bool[1]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
                 edge_set = [false, true, true, false]
-                reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                reference_forest = [
+                    rootedtree([3], t.color_sequence[5:5]),
                     rootedtree([2, 3, 4], t.color_sequence[2:4]),
-                    rootedtree([1], t.color_sequence[1:1])]
+                    rootedtree([1], t.color_sequence[1:1]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 4, 3], rand(Bool, 5))
                 edge_set = [false, true, false, false]
-                reference_forest = [rootedtree([4], t.color_sequence[4:4]),
+                reference_forest = [
+                    rootedtree([4], t.color_sequence[4:4]),
                     rootedtree([3], t.color_sequence[5:5]),
                     rootedtree([2, 3], t.color_sequence[2:3]),
-                    rootedtree([1], t.color_sequence[1:1])]
+                    rootedtree([1], t.color_sequence[1:1]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3, 3])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 2, 2, 2], rand(Bool, 5))
                 edge_set = [false, false, true, true]
-                reference_forest = [rootedtree([2], t.color_sequence[2:2]),
+                reference_forest = [
+                    rootedtree([2], t.color_sequence[2:2]),
                     rootedtree([2], t.color_sequence[3:3]),
-                    rootedtree([1, 2, 2], t.color_sequence[[1, 4, 5]])]
+                    rootedtree([1, 2, 2], t.color_sequence[[1, 4, 5]]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
                 edge_set = [false, false, false, true]
-                reference_forest = [rootedtree([3], t.color_sequence[3:3]),
+                reference_forest = [
+                    rootedtree([3], t.color_sequence[3:3]),
                     rootedtree([2], t.color_sequence[2:2]),
                     rootedtree([2], t.color_sequence[4:4]),
-                    rootedtree([1, 2], t.color_sequence[[1, 5]])]
+                    rootedtree([1, 2], t.color_sequence[[1, 5]]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3, 2])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 2, 2], rand(Bool, 5))
@@ -1408,54 +1462,60 @@ using JET: @test_opt
                 reference_forest = [rootedtree([1, 2, 3, 2, 2], t.color_sequence[:])]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
                 edge_set = [true, true, false, false]
-                reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                reference_forest = [
+                    rootedtree([3], t.color_sequence[5:5]),
                     rootedtree([2], t.color_sequence[4:4]),
-                    rootedtree([1, 2, 3], t.color_sequence[1:3])]
+                    rootedtree([1, 2, 3], t.color_sequence[1:3]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 2, 3], rand(Bool, 5))
                 edge_set = [false, true, false, false]
-                reference_forest = [rootedtree([2, 3], t.color_sequence[2:3]),
+                reference_forest = [
+                    rootedtree([2, 3], t.color_sequence[2:3]),
                     rootedtree([3], t.color_sequence[5:5]),
                     rootedtree([2], t.color_sequence[4:4]),
-                    rootedtree([1], t.color_sequence[1:1])]
+                    rootedtree([1], t.color_sequence[1:1]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 2, 3])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             let t = rootedtree([1, 2, 3, 3, 3], rand(Bool, 5))
                 edge_set = [false, true, true, false]
-                reference_forest = [rootedtree([3], t.color_sequence[5:5]),
+                reference_forest = [
+                    rootedtree([3], t.color_sequence[5:5]),
                     rootedtree([2, 3, 3], t.color_sequence[2:4]),
-                    rootedtree([1], t.color_sequence[1:1])]
+                    rootedtree([1], t.color_sequence[1:1]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2, 3])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
 
             # additional tests not included in the examples of the paper
@@ -1463,14 +1523,15 @@ using JET: @test_opt
                 edge_set = [true, false, true, true]
                 reference_forest = [
                     rootedtree([1, 2, 3, 2], t.color_sequence[[1, 4, 5, 2]]),
-                    rootedtree([3], t.color_sequence[3:3])]
+                    rootedtree([3], t.color_sequence[3:3]),
+                ]
                 sort!(reference_forest)
                 @test sort!(collect(PartitionForestIterator(t, edge_set))) ==
-                      reference_forest
+                    reference_forest
 
                 reference_skeleton = rootedtree([1, 2])
                 @test reference_skeleton.level_sequence ==
-                      partition_skeleton(t, edge_set).level_sequence
+                    partition_skeleton(t, edge_set).level_sequence
             end
         end
 
@@ -1504,24 +1565,24 @@ using JET: @test_opt
                 [
                     rootedtree([1], Bool[1]),
                     rootedtree([1], Bool[1]),
-                    rootedtree([1, 2], Bool[0, 0])
+                    rootedtree([1, 2], Bool[0, 0]),
                 ],
                 [
                     rootedtree([1], Bool[0]),
                     rootedtree([1], Bool[1]),
-                    rootedtree([1, 2], Bool[1, 0])
+                    rootedtree([1, 2], Bool[1, 0]),
                 ],
                 [
                     rootedtree([1], Bool[0]),
                     rootedtree([1], Bool[1]),
-                    rootedtree([1, 2], Bool[0, 1])
+                    rootedtree([1, 2], Bool[0, 1]),
                 ],
                 [
                     rootedtree([1], Bool[0]),
                     rootedtree([1], Bool[0]),
                     rootedtree([1], Bool[1]),
-                    rootedtree([1], Bool[1])
-                ]
+                    rootedtree([1], Bool[1]),
+                ],
             ]
             reference_skeletons = [
                 rootedtree([1], Bool[1]),
@@ -1531,7 +1592,7 @@ using JET: @test_opt
                 rootedtree([1, 2, 2], Bool[1, 1, 0]),
                 rootedtree([1, 2, 3], Bool[1, 0, 0]),
                 rootedtree([1, 2, 3], Bool[1, 0, 1]),
-                rootedtree([1, 2, 3, 3], Bool[1, 0, 1, 0])
+                rootedtree([1, 2, 3, 3], Bool[1, 0, 1, 0]),
             ]
             for forest in reference_forests
                 sort!(forest)
@@ -1555,14 +1616,14 @@ using JET: @test_opt
     @testset "Order conditions" begin
         # Runge-Kutta method SSPRK33 of order 3
         @testset "RungeKuttaMethod, SSPRK33" begin
-            A = [0 0 0; 1 0 0; 1/4 1/4 0]
+            A = [0 0 0; 1 0 0; 1 / 4 1 / 4 0]
             b = [1 / 6, 1 / 6, 2 / 3]
             rk = RungeKuttaMethod(A, b)
             show(IOContext(stdout, :compact => false), rk)
 
             for order in 1:3
                 for t in RootedTreeIterator(order)
-                    @test residual_order_condition(t, rk)≈0 atol=eps()
+                    @test residual_order_condition(t, rk) ≈ 0 atol = eps()
                 end
             end
 
@@ -1574,7 +1635,7 @@ using JET: @test_opt
                 @test res > 10 * eps()
             end
 
-            A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
+            A = @SArray [0 0 0; 1 0 0; 1 / 4 1 / 4 0]
             b = @SArray [1 / 6, 1 / 6, 2 / 3]
             rk = RungeKuttaMethod(A, b)
             show(IOContext(stdout, :compact => true), rk)
@@ -1597,9 +1658,9 @@ using JET: @test_opt
                 for t in RootedTreeIterator(order)
                     @test elementary_weight(t, rk.A, rk.b, rk.c) ≈ elementary_weight(t, rk)
                     @test derivative_weight(t, RungeKuttaMethod(rk.A, rk.b, rk.c)) ≈
-                          derivative_weight(t, rk)
+                        derivative_weight(t, rk)
                     @test residual_order_condition(t, RungeKuttaMethod(rk.A, rk.b, rk.c)) ≈
-                          residual_order_condition(t, rk)
+                        residual_order_condition(t, rk)
                 end
             end
         end
@@ -1615,7 +1676,7 @@ using JET: @test_opt
 
             for order in 1:1
                 for t in BicoloredRootedTreeIterator(order)
-                    @test residual_order_condition(t, ark)≈0 atol=eps()
+                    @test residual_order_condition(t, ark) ≈ 0 atol = eps()
                 end
             end
 
@@ -1633,18 +1694,18 @@ using JET: @test_opt
             # Geometric numerical integration
             # Table II.2.1
             As = [
-                [0 0; 1//2 1//2],
-                [1//2 0; 1//2 0]
+                [0 0; 1 // 2 1 // 2],
+                [1 // 2 0; 1 // 2 0],
             ]
             bs = [
                 [1 // 2, 1 // 2],
-                [1 // 2, 1 // 2]
+                [1 // 2, 1 // 2],
             ]
             ark = AdditiveRungeKuttaMethod(As, bs)
 
             for order in 1:2
                 for t in BicoloredRootedTreeIterator(order)
-                    @test residual_order_condition(t, ark)≈0 atol=eps()
+                    @test residual_order_condition(t, ark) ≈ 0 atol = eps()
                 end
             end
 
@@ -1662,18 +1723,18 @@ using JET: @test_opt
             # Geometric numerical integration
             # Table II.2.2
             As = [
-                [0 0 0; 5//24 1//3 -1//24; 1//6 2//3 1//6],
-                [1//6 -1//6 0; 1//6 1//3 0; 1//6 5//6 0]
+                [0 0 0; 5 // 24 1 // 3 -1 // 24; 1 // 6 2 // 3 1 // 6],
+                [1 // 6 -1 // 6 0; 1 // 6 1 // 3 0; 1 // 6 5 // 6 0],
             ]
             bs = [
                 [1 // 6, 2 // 3, 1 // 6],
-                [1 // 6, 2 // 3, 1 // 6]
+                [1 // 6, 2 // 3, 1 // 6],
             ]
             ark = AdditiveRungeKuttaMethod(As, bs)
 
             for order in 1:4
                 for t in BicoloredRootedTreeIterator(order)
-                    @test residual_order_condition(t, ark)≈0 atol=eps()
+                    @test residual_order_condition(t, ark) ≈ 0 atol = eps()
                 end
             end
 
@@ -1691,18 +1752,18 @@ using JET: @test_opt
             # "Generalized Split-Explicit Runge-Kutta Methods for the
             # Compressible Euler Equations".
             # Monthly Weather Review, 142, 2067-2081
-            A_explicit = @SArray [0 0 0; 1//2 0 0; -1 2 0]
+            A_explicit = @SArray [0 0 0; 1 // 2 0 0; -1 2 0]
             b_explicit = @SArray [1 // 6, 2 // 3, 1 // 6]
             rk_explicit = RungeKuttaMethod(A_explicit, b_explicit)
             β = sqrt(3) / 3
-            A_implicit = @SArray [0 0 0; -β/2 (1 + β)/2 0; (3 + 5β)/2 -1-3β (1 + β)/2]
+            A_implicit = @SArray [0 0 0; -β / 2 (1 + β) / 2 0; (3 + 5β) / 2 -1 - 3β (1 + β) / 2]
             b_implicit = @SArray [1 // 6, 2 // 3, 1 // 6]
             rk_implicit = RungeKuttaMethod(A_implicit, b_implicit)
             ark = AdditiveRungeKuttaMethod([rk_explicit, rk_implicit])
 
             for order in 1:3
                 for t in BicoloredRootedTreeIterator(order)
-                    @test residual_order_condition(t, ark)≈0 atol=eps()
+                    @test residual_order_condition(t, ark) ≈ 0 atol = eps()
                 end
             end
 
@@ -1720,33 +1781,37 @@ using JET: @test_opt
             # "Additive Runge-Kutta schemes for convection-diffusion-reaction equations."
             # Applied Numerical Mathematics 44, no. 1-2 (2003): 139-181.
             # https://doi.org/10.1016/S0168-9274(02)00138-1
-            A_explicit = @SArray [0 0 0 0
-                                  1767732205903/2027836641118 0 0 0
-                                  5535828885825/10492691773637 788022342437/10882634858940 0 0
-                                  6485989280629/16251701735622 -4246266847089/9704473918619 10755448449292/10357097424841 0]
+            A_explicit = @SArray [
+                0 0 0 0
+                1767732205903 / 2027836641118 0 0 0
+                5535828885825 / 10492691773637 788022342437 / 10882634858940 0 0
+                6485989280629 / 16251701735622 -4246266847089 / 9704473918619 10755448449292 / 10357097424841 0
+            ]
             b_explicit = @SArray [
                 1471266399579 / 7840856788654,
                 -4482444167858 / 7529755066697,
                 11266239266428 / 11593286722821,
-                1767732205903 / 4055673282236
+                1767732205903 / 4055673282236,
             ]
             rk_explicit = RungeKuttaMethod(A_explicit, b_explicit)
-            A_implicit = @SArray [0 0 0 0
-                                  1767732205903/4055673282236 1767732205903/4055673282236 0 0
-                                  2746238789719/10658868560708 -640167445237/6845629431997 1767732205903/4055673282236 0
-                                  1471266399579/7840856788654 -4482444167858/7529755066697 11266239266428/11593286722821 1767732205903/4055673282236]
+            A_implicit = @SArray [
+                0 0 0 0
+                1767732205903 / 4055673282236 1767732205903 / 4055673282236 0 0
+                2746238789719 / 10658868560708 -640167445237 / 6845629431997 1767732205903 / 4055673282236 0
+                1471266399579 / 7840856788654 -4482444167858 / 7529755066697 11266239266428 / 11593286722821 1767732205903 / 4055673282236
+            ]
             b_implicit = @SArray [
                 1471266399579 / 7840856788654,
                 -4482444167858 / 7529755066697,
                 11266239266428 / 11593286722821,
-                1767732205903 / 4055673282236
+                1767732205903 / 4055673282236,
             ]
             rk_implicit = RungeKuttaMethod(A_implicit, b_implicit)
             ark = AdditiveRungeKuttaMethod([rk_explicit, rk_implicit])
 
             for order in 1:3
                 for t in BicoloredRootedTreeIterator(order)
-                    @test residual_order_condition(t, ark)≈0 atol=eps()
+                    @test residual_order_condition(t, ark) ≈ 0 atol = eps()
                 end
             end
 
@@ -1762,13 +1827,13 @@ using JET: @test_opt
         @testset "AdditiveRungeKuttaMethod, SSPRK33 three times" begin
             # Using the same method multiple times is equivalent to using a plain RK
             # method without any splitting/partitioning/decomposition
-            A = @SArray [0 0 0; 1 0 0; 1/4 1/4 0]
+            A = @SArray [0 0 0; 1 0 0; 1 / 4 1 / 4 0]
             b = @SArray [1 / 6, 1 / 6, 2 / 3]
             rk = RungeKuttaMethod(A, b)
             ark = AdditiveRungeKuttaMethod([rk, rk, rk])
 
             let t = rootedtree([1, 2, 2], [1, 2, 3])
-                @test residual_order_condition(t, ark)≈0 atol=eps()
+                @test residual_order_condition(t, ark) ≈ 0 atol = eps()
             end
 
             let t = rootedtree([1, 2, 3, 2], [1, 2, 3, 1])
@@ -1777,24 +1842,28 @@ using JET: @test_opt
         end
 
         @testset "RosenbrockMethod, original Rosenbrock" begin
-            γ = [1-sqrt(2) / 2 0;
-                 0 1-sqrt(2) / 2]
-            A = [0 0;
-                 (sqrt(2) - 1)/2 0]
+            γ = [
+                1 - sqrt(2) / 2 0;
+                0 1 - sqrt(2) / 2
+            ]
+            A = [
+                0 0;
+                (sqrt(2) - 1) / 2 0
+            ]
             b = [0, 1]
             ros = @inferred RosenbrockMethod(γ, A, b)
 
             # second-order accurate
             @test abs(@inferred(residual_order_condition(rootedtree(Int[]), ros))) <
-                  10 * eps()
+                10 * eps()
             @test abs(@inferred(residual_order_condition(rootedtree(Int[1]), ros))) <
-                  10 * eps()
+                10 * eps()
             @test abs(@inferred(residual_order_condition(rootedtree(Int[1, 2]), ros))) <
-                  10 * eps()
+                10 * eps()
             @test abs(@inferred(residual_order_condition(rootedtree(Int[1, 2, 3]), ros))) >
-                  0.04
+                0.04
             @test abs(@inferred(residual_order_condition(rootedtree(Int[1, 2, 2]), ros))) >
-                  0.14
+                0.14
         end
 
         @testset "RosenbrockMethod, GRK4A (Kaps and Rentrop, 1979)" begin
@@ -1802,14 +1871,18 @@ using JET: @test_opt
             # Generalized Runge-Kutta methods of order four with stepsize control
             # for stiff ordinary differential equations
             # https://doi.org/10.1007/BF01396495
-            γ = [0.395 0 0 0;
-                 -0.767672395484 0.395 0 0;
-                 -0.851675323742 0.522967289188 0.395 0;
-                 0.288463109545 0.880214273381e-1 -0.337389840627 0.395]
-            A = [0 0 0 0;
-                 0.438 0 0 0;
-                 0.796920457938 0.730795420615e-1 0 0;
-                 0.796920457938 0.730795420615e-1 0 0]
+            γ = [
+                0.395 0 0 0;
+                -0.767672395484 0.395 0 0;
+                -0.851675323742 0.522967289188 0.395 0;
+                0.288463109545 0.880214273381e-1 -0.337389840627 0.395
+            ]
+            A = [
+                0 0 0 0;
+                0.438 0 0 0;
+                0.796920457938 0.730795420615e-1 0 0;
+                0.796920457938 0.730795420615e-1 0 0
+            ]
             b = [0.199293275701, 0.482645235674, 0.680614886256e-1, 0.25]
             ros = @inferred RosenbrockMethod(γ, A, b)
 
@@ -1888,10 +1961,12 @@ using JET: @test_opt
     end # @testset "plots"
 
     @testset "Aqua" begin
-        Aqua.test_all(RootedTrees;
-                      ambiguities = (; exclude = [getindex]),
-                      # Requires.jl is not loaded on new versions of Julia
-                      stale_deps = (; ignore = [:Requires]))
+        Aqua.test_all(
+            RootedTrees;
+            ambiguities = (; exclude = [getindex]),
+            # Requires.jl is not loaded on new versions of Julia
+            stale_deps = (; ignore = [:Requires])
+        )
     end
 
     @testset "ExplicitImports" begin
@@ -1926,13 +2001,13 @@ using JET: @test_opt
         @test_opt target_modules = (RootedTrees,) hash(ct)
 
         # RungeKuttaMethod construction
-        A = [0 0; 1//2 0]
+        A = [0 0; 1 // 2 0]
         b = [0, 1]
-        c = [0, 1//2]
+        c = [0, 1 // 2]
         @test_opt target_modules = (RootedTrees,) RungeKuttaMethod(A, b, c)
 
         # RosenbrockMethod construction
-        @test_opt target_modules = (RootedTrees,) RosenbrockMethod([1//2;;], [0 0; 1 0], [1//2, 1//2])
+        @test_opt target_modules = (RootedTrees,) RosenbrockMethod([1 // 2;;], [0 0; 1 0], [1 // 2, 1 // 2])
 
         # SubtreeIterator
         @test_opt target_modules = (RootedTrees,) RootedTrees.SubtreeIterator(t)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)