### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -31,47 +31,5 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-          show-versioninfo: true
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-        env:
-          PYTHON: ""
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-        env:
-          PYTHON: ""
-      - name: Fix weird Conda.jl/PyCall.jl/SymPy.jl build error
-        env:
-          PYTHON: ""
-        shell: julia --color=yes {0}
-        run: |
-          using Pkg
-          Pkg.activate("docs")
-          println("Try instantiating the docs environment")
-          try
-            Pkg.instantiate()
-            println("Successfully instantiated the docs environment")
-          catch e
-            display(e)
-          end
-          println("Try building SymPy")
-          try
-            Pkg.build("SymPy")
-            import SymPy
-            println("Successfully built SymPy")
-          catch e
-            display(e)
-          end
-      - name: Build and deploy documentation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
-          PYTHON: ""
-        run: julia --project=docs --color=yes docs/make.jl
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,8 @@ on:
 jobs:
   test:
     if: false  # Temporarily disabled - see #213
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.23.5
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,9 @@
 using Documenter
 import Pkg
 
+# Use a headless GR backend so Plots-based examples render in CI without a display
+ENV["GKSwstype"] = "100"
+
 # Fix for https://github.com/trixi-framework/Trixi.jl/issues/668
 # to allow building the docs locally
 if (get(ENV, "CI", nothing) != "true") &&


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary
Converts the remaining inline CI workflows to the centralized SciML/.github reusable workflows, pinned at `@v1`, each with `secrets: "inherit"`. `Tests.yml` was already a `tests.yml@v1` caller and is unchanged.

### Converted (inline -> central)
- **Documenter.yml** -> `documentation.yml@v1`
- **FormatCheck.yml** (fredrikekre/runic-action) -> `runic.yml@v1`
- **SpellCheck.yml** (crate-ci/typos) -> `spellcheck.yml@v1`
- **Downgrade.yml** -> `downgrade.yml@v1` (kept `if: false` per #213; `julia-version: 1.10`, `skip: Pkg,TOML`)

### Added
- None — all five central caller types were already present or converted.

### Other changes
- `docs/make.jl`: added `ENV["GKSwstype"] = "100"` so Plots/GR examples still render headlessly. The old inline Documenter workflow set this as a job-level env var, but the central `documentation.yml@v1` caller exposes no way to inject env vars, so it moves into `make.jl`.
- `dependabot.yml`: removed the `crate-ci/typos` ignore block (typos is now centralized). The `github-actions` (weekly, `/`) and `julia` (daily, dirs `/`,`/docs`,`/test`, group all-julia-packages `*`) blocks are preserved.

### Checks
- Runic: ran `Runic.main(["--inplace","."])` locally — source already clean (no formatting changes beyond the make.jl edit).
- Typos: `typos .` exits 0 — 0 typos fixed.

### Behavior notes / risks
- The old inline Documenter workflow set `PYTHON: ""` and had a "Fix weird Conda.jl/PyCall.jl/SymPy.jl build error" step. The docs use SymPy (compat `1, 2`). SymPy 2 uses PythonCall rather than PyCall/Conda, so the `PYTHON=""` workaround and the SymPy rebuild step should be obsolete; the central caller does a plain `Pkg.develop + Pkg.instantiate`. If the docs env resolves SymPy 1 (PyCall), the docs build could regress — watch the Documentation check on this PR.
- The central documentation caller enables coverage (codecov "docs" flag); the old inline build did not collect coverage. This is the intended end-state behavior.

### Branch protection
Check names change (e.g. the format check job is now named "Runic Format Check", spellcheck "Spell Check with Typos", docs "Build and Deploy Documentation"). Any required-status-check rules in branch protection will need updating to the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)