### PR TITLE
Migrate DocPreviewCleanup to centralized SciML caller

### DIFF
--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,32 +1,10 @@
-name: Doc Preview Cleanup
-
+name: "Doc Preview Cleanup"
 on:
   pull_request:
     types: [closed]
-
+permissions:
+  contents: write
 jobs:
-  doc-preview-cleanup:
-    # Do not run on forks to avoid authorization errors
-    # Source: https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18
-    if: github.repository_owner == 'SciML'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-
-      - name: Delete preview and history
-        shell: bash
-        run: |
-            git config user.name "Documenter.jl"
-            git config user.email "documenter@juliadocs.github.io"
-            git rm -rf --ignore-unmatch "previews/PR$PRNUM"
-            git commit -m "delete preview" --allow-empty
-            git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
-        env:
-            PRNUM: ${{ github.event.number }}
-
-      - name: Push changes
-        run: |
-            git push --force origin gh-pages-new:gh-pages
+  cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Migrates the doc preview cleanup workflow from the hand-rolled inline implementation to the centralized reusable workflow in `SciML/.github`.

The inline `.github/workflows/DocPreviewCleanup.yml` previously contained custom logic that checks out the `gh-pages` branch, deletes `previews/PR$PRNUM`, squashes the history, and force-pushes back to `gh-pages` (standard Documenter doc-preview cleanup). This is replaced by a thin caller of the centralized reusable workflow `SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1`, which performs the equivalent cleanup. This is a true behavioral replacement.

## Changes

- Replace the inline `DocPreviewCleanup.yml` with a caller of `SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1` (`secrets: inherit`, `permissions: contents: write`).

This is a draft PR; please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)