### PR TITLE
Fix docs build: point PyCall at Conda Python so SymPy loads

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -31,5 +31,28 @@ concurrency:
 
 jobs:
   build:
-    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
-    secrets: "inherit"
+    name: "Build and Deploy Documentation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
+      # The RK order conditions tutorial loads SymPy (via PyCall). Setting
+      # `PYTHON: ""` forces PyCall to build against the private Conda.jl Python
+      # into which SymPy installs `sympy`, instead of the system `python3` on
+      # the runner (which has no usable `libpython`/`sympy`). The shared
+      # SciML reusable documentation workflow does not set this, so this job is
+      # kept self-contained.
+      - name: Install dependencies
+        env:
+          PYTHON: ""
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          PYTHON: ""
+        run: julia --color=yes --project=docs/ docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,18 @@ import Pkg
 # Use a headless GR backend so Plots-based examples render in CI without a display
 ENV["GKSwstype"] = "100"
 
+# The RK order conditions tutorial uses SymPy, which relies on PyCall. By
+# default PyCall builds against any system Python it finds on `PATH` (e.g.
+# `/usr/bin/python3` on the GitHub runners), which has no `sympy` installed, so
+# `using SymPy` fails. Setting `PYTHON=""` makes PyCall use the private Conda.jl
+# Python into which SymPy installs `sympy` automatically. The repository's
+# previous (non-centralized) documentation workflow set this as an environment
+# variable; doing it here keeps the docs build self-contained regardless of the
+# CI workflow.
+ENV["PYTHON"] = ""
+Pkg.build("PyCall")
+Pkg.build("SymPy")
+
 # Fix for https://github.com/trixi-framework/Trixi.jl/issues/668
 # to allow building the docs locally
 if (get(ENV, "CI", nothing) != "true") &&


### PR DESCRIPTION
## Problem

The documentation build on `main` is failing (the only red check on the default branch). After CI was centralized onto the reusable SciML documentation workflow (#219), the docs build can no longer build the SymPy/PyCall-based RK order conditions tutorial:

- On the runner image at the time of the original master failure, PyCall built against the system `/usr/bin/python3` (which has no `sympy`), and `using SymPy` failed at runtime with `ModuleNotFoundError: No module named 'sympy'` / `ref of NULL PyObject`, terminating `makedocs` on `:setup_block` / `:example_block`.
- On the current `ubuntu-latest` image, PyCall now fails even earlier, during the workflow's `Pkg.instantiate()` install step, because that `python3` (3.12) has no usable shared `libpython`: `ERROR: Error building PyCall: Couldn't find libpython; check your PYTHON environment variable.`

## Root cause

The RK order conditions tutorial loads `SymPy` (via PyCall). PyCall, by default, builds against whatever system Python it finds on `PATH`. The repository's old (pre-#219) `Documenter.yml` set `PYTHON: ""` on every relevant step, forcing PyCall to use the private Conda.jl Python into which SymPy auto-installs `sympy`. When CI was centralized onto the reusable workflow, that `PYTHON=""` was dropped — and the reusable `documentation.yml@v1` exposes no input/env hook to set it — so PyCall reverted to the (now unbuildable) system Python.

## Fix

1. **`.github/workflows/Documenter.yml`** — make the Documentation job self-contained again and set `PYTHON: ""` on the install and build steps, so PyCall builds against the Conda Python. (This is the load-bearing CI fix; the reusable workflow cannot build PyCall/SymPy docs.)
2. **`docs/make.jl`** — also set `ENV["PYTHON"] = ""` and rebuild PyCall/SymPy at the top, so local docs builds work out-of-the-box regardless of the surrounding environment.

## Local verification (Julia 1.12, the CI "1" channel)

- Reproduced the runtime failure by pointing PyCall at a Python venv without `sympy`: `using SymPy` failed with `ModuleNotFoundError: No module named 'sympy'` / `ref of NULL PyObject`.
- Observed the install-step `libpython` build failure in the PR CI run that used the bare reusable workflow.
- Confirmed `PYTHON=""` makes `Pkg.build("PyCall")` build against the Conda Python.
- Ran the full `docs/make.jl` to completion twice: exit code 0, all stages (Doctest, ExpandTemplates, CrossReferences, CheckDocument, RenderDocument, HTMLWriter) pass; the only warning is the expected "Skipping deployment" for a local run.

`docs/make.jl` is Runic-clean; `Documenter.yml` is valid YAML.

Please ignore until reviewed by @ChrisRackauckas