### PR TITLE
Document public API coverage

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+RootedTrees = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 

--- a/src/RootedTrees.jl
+++ b/src/RootedTrees.jl
@@ -1499,6 +1499,21 @@ end
 
 @deprecate elementary_differential(t::RootedTree) elementary_differential_latexstring(t)
 
+@doc """
+    elementary_differential(t::RootedTree)
+
+Deprecated alias for [`elementary_differential_latexstring`](@ref).
+
+# Examples
+
+```julia
+using RootedTrees
+
+t = rootedtree([1])
+elementary_differential_latexstring(t)
+```
+""" elementary_differential
+
 """
     elementary_differential_latexstring(t::RootedTree)
 

--- a/test/qa/public_api_docs.jl
+++ b/test/qa/public_api_docs.jl
@@ -1,0 +1,17 @@
+using RootedTrees
+using Test
+
+@testset "public API documentation" begin
+    public_names = filter(!=(:RootedTrees), names(RootedTrees; all = false, imported = false))
+
+    missing_docs = Symbol[]
+    for name in public_names
+        binding = Docs.Binding(RootedTrees, name)
+        Docs.hasdoc(binding) || push!(missing_docs, name)
+    end
+    @test isempty(missing_docs)
+
+    api_page = read(joinpath(pkgdir(RootedTrees), "docs", "src", "api_reference.md"), String)
+    @test occursin("@autodocs", api_page)
+    @test occursin("Modules = [RootedTrees]", api_page)
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, RootedTrees, Test
 using JET
 
+include("public_api_docs.jl")
+
 run_qa(
     RootedTrees;
     explicit_imports = true,


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- documents the deprecated exported `elementary_differential` alias on the generated binding after `@deprecate`
- adds RootedTrees to the docs environment so `@autodocs` resolves the package explicitly
- adds a QA guard that exported public bindings have docstrings and that the API page includes the RootedTrees autodocs block

## Validation
- `git diff --check`
- `timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`\n- `timeout 3600 julia --project=test/qa test/qa/qa.jl`\n- `timeout 3600 julia --project=docs docs/make.jl`\n- `timeout 3600 julia --project=. -e 'using Runic; exit(Runic.main(ARGS))' -- --check .`