### PR TITLE
Release prep: bump RootedTrees to 2.25.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootedTrees"
 uuid = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 authors = ["Hendrik Ranocha <mail@ranocha.de> and contributors"]
-version = "2.25.2"
+version = "2.25.3"
 
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test scaffolding changes since 2.25.2 (no functional changes).