### PR TITLE
QA: load Plots so the PlotsExt extension is actually scanned

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,8 +2,10 @@
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RootedTrees = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Plots = "1.39"
 SciMLTesting = "2.4"
+Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,9 @@
 [deps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RootedTrees = "47965b36-3f3e-11e9-0dcf-4570dfd42a8c"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 
 [compat]
+Plots = "1.39"
 SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,8 +1,15 @@
 using SciMLTesting, RootedTrees
+using Test
 
 # ExplicitImports only sees an extension module once its trigger package is loaded,
 # so `using Plots` is what makes `PlotsExt` part of the QA scan.
 using Plots
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(RootedTrees, :PlotsExt) !== nothing
+end
 
 run_qa(
     RootedTrees;

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,2 +1,18 @@
 using SciMLTesting, RootedTrees
-run_qa(RootedTrees)
+
+# ExplicitImports only sees an extension module once its trigger package is loaded,
+# so `using Plots` is what makes `PlotsExt` part of the QA scan.
+using Plots
+
+run_qa(
+    RootedTrees;
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (;
+            # RootedTrees: `_distinguishable_colors` is RootedTrees' own internal hook,
+            # defined precisely so that `PlotsExt` can fill it in. ExplicitImports does
+            # not treat an extension as internal to its parent package, so the access
+            # has to be ignored here.
+            ignore = (:_distinguishable_colors,),
+        ),
+    ),
+)


### PR DESCRIPTION
**This is a QA-infrastructure change opened for review, not a merge request.** RootedTrees.jl is primarily maintained by @ranocha outside SciML, so this is offered as a suggestion — please treat it as a proposal to comment on rather than something to merge as-is. Please ignore until reviewed by @ChrisRackauckas.

## Problem

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module. ExplicitImports *does* know about extensions — it reads the `[extensions]` table out of `Project.toml` and adds each extension to the set of checked modules — but only when the extension module actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep has been loaded. The QA environment (`test/qa/Project.toml`) did not depend on `Plots`, so `PlotsExt` was **never scanned by QA**.

This is invisible in the test summary: each ExplicitImports check folds all submodules into a single `@test`, so the QA output is byte-identical whether or not the extension is covered.

## Change

* `test/qa/Project.toml`: add `Plots` under `[deps]` (same UUID as the root `[weakdeps]` entry) and a `[compat]` entry mirroring the root `Plots = "1.39"` bound. `Test` is added alongside it for the load guard below.
* `test/qa/qa.jl`: `using Plots` before `run_qa`, with a comment explaining why.
* `test/qa/qa.jl`: a load guard asserting the extension really materialized (see below).

## Coverage

| Extension | Status |
|---|---|
| `PlotsExt` | now scanned |

Nothing is left out — `Plots` is the only weakdep, and it resolves and loads fine in the QA environment.

### Proof that `PlotsExt` is actually scanned

Run from the QA environment (ExplicitImports stacked in from a scratch env so it does not pollute `test/qa/Project.toml`):

**With `Plots` loaded (this PR):**
```
get_extension(RootedTrees, :PlotsExt) => PlotsExt
explicit_imports modules => Module[RootedTrees, PlotsExt]
```

**Without `Plots` loaded (`main` today):**
```
get_extension(RootedTrees, :PlotsExt) => nothing
explicit_imports modules => Module[RootedTrees]
```

Independently corroborated by the fact that adding `using Plots` immediately produced a *new* ExplicitImports failure that `main` never reported (below).

## Load guard: keeping the coverage from silently regressing

The `ext_mod === nothing && continue` above is a **silent** skip. If someone later breaks `PlotsExt`'s precompilation, or the weakdep drops out of the QA environment, `Base.get_extension` returns `nothing`, ExplicitImports quietly checks fewer modules, and `run_qa` still reports a completely green summary — coverage falls back to zero with nothing failing. Merely adding the dependency is therefore not self-defending.

So the PR also asserts the extension exists, rather than trusting a green `run_qa`:

```julia
# ExplicitImports silently skips an extension that fails to load, so assert the
# extension modules actually exist rather than trusting a green run_qa.
@testset "Extensions loaded" begin
    @test Base.get_extension(RootedTrees, :PlotsExt) !== nothing
end
```

This is the one assertion in the file whose failure unambiguously means "the extension is no longer being scanned."

## Finding surfaced, and the one ignore entry added

Once `PlotsExt` was in scope, `all_qualified_accesses_are_public` errored:

```
Module `PlotsExt` has explicit imports of names from modules in which they are not public:
- `_distinguishable_colors` is not public in `RootedTrees` but it was imported from
  `RootedTrees` at ext/PlotsExt.jl:7:13
```

**Justification for ignoring:** `RootedTrees._distinguishable_colors` is RootedTrees' *own* internal hook — it exists specifically so `PlotsExt` can define a method for it (`RootedTrees._distinguishable_colors(n) = Plots.distinguishable_colors(n)`). An extension filling in its parent package's internal hook is exactly the intended design; ExplicitImports simply does not classify an extension module as internal to its parent, so it flags the access. There is no public spelling to switch to, and promoting an underscore-prefixed implementation hook to public API (which would also require documenting it, and would make it subject to SemVer) would be the wrong fix. So it is ignored, with a comment naming the owner and the reason:

```julia
ei_kwargs = (;
    all_qualified_accesses_are_public = (;
        # RootedTrees: `_distinguishable_colors` is RootedTrees' own internal hook,
        # defined precisely so that `PlotsExt` can fill it in. ExplicitImports does
        # not treat an extension as internal to its parent package, so the access
        # has to be ignored here.
        ignore = (:_distinguishable_colors,),
    ),
)
```

No check is disabled, nothing is marked `@test_broken`, and no extension source needed fixing — `ext/PlotsExt.jl` is already clean (`using Plots: Plots`, `using RootedTrees: RootedTrees`) and is untouched by this PR.

## Local result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch:

```
Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  1m23.0s
     Testing RootedTrees tests passed
```

21 rather than 20 because of the added load-guard `@test`. For contrast, the intermediate state (Plots loaded, no ignore entry) gave `19 passed, 0 failed, 1 errored` — which is the evidence that the extension genuinely entered the scan.

`test/qa/Manifest.toml` is a local build artifact and is not committed (`**/Manifest.toml` is already gitignored).
