### PR TITLE
compat: declare SciMLTesting 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ LinearAlgebra = "1"
 Plots = "1.39"
 Preferences = "1.3"
 RecipesBase = "1.3.1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,9 @@ LinearAlgebra = "1"
 Plots = "1.39"
 Preferences = "1.3"
 RecipesBase = "1.3.1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"


### PR DESCRIPTION
## Summary

Declare the missing SciMLTesting compatibility bound as 2.10 and add its UUID to package test extras in the affected manifest(s):

- Project.toml

This PR is manifest-only. It does not change source behavior, tests, public APIs, or documentation.

## Verification

- Julia TOML.parsefile passed for all TOML files in the 20-repository batch.
- Pkg.Types.read_project passed for all 32 changed manifests, including the new compat and extras entries.
- git diff --check passed for all 20 repositories.
- typos passed on all changed TOML files.
- Runic was not run because the diff contains TOML only.
- No test suite was run because no source or test files changed.

Please ignore this draft until reviewed by @ChrisRackauckas.