### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ LinearAlgebra = "1"
 Plots = "1.39"
 Preferences = "1.3"
 RecipesBase = "1.3.1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,9 @@ LinearAlgebra = "1"
 Plots = "1.39"
 Preferences = "1.3"
 RecipesBase = "1.3.1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.