### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,63 @@
+using RootedTrees, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Classical explicit RK4 tableau
+A_rk4 = [
+    0 0 0 0
+    1 // 2 0 0 0
+    0 1 // 2 0 0
+    0 0 1 0
+]
+b_rk4 = [1 // 6, 1 // 3, 1 // 3, 1 // 6]
+rk4 = RungeKuttaMethod(A_rk4, b_rk4)
+
+# =============================================================================
+# Tree enumeration
+# =============================================================================
+
+SUITE["enumeration"] = BenchmarkGroup()
+
+SUITE["enumeration"]["iterator_order5"] = @benchmarkable collect(RootedTreeIterator(5))
+SUITE["enumeration"]["iterator_order7"] = @benchmarkable collect(RootedTreeIterator(7))
+SUITE["enumeration"]["count_trees"] = @benchmarkable count_trees(8)
+
+trees7 = collect(RootedTreeIterator(7))
+SUITE["enumeration"]["canonical"] = @benchmarkable RootedTrees.canonical_representation.($trees7)
+
+# =============================================================================
+# Order conditions
+# =============================================================================
+
+SUITE["order_conditions"] = BenchmarkGroup()
+
+function sum_residuals(order)
+    res = 0.0
+    for t in RootedTreeIterator(order)
+        res += abs(residual_order_condition(t, rk4))
+    end
+    return res
+end
+
+SUITE["order_conditions"]["residuals_order4"] = @benchmarkable sum_residuals(4)
+SUITE["order_conditions"]["residuals_order5"] = @benchmarkable sum_residuals(5)
+
+t8 = rootedtree([1, 2, 3, 2, 3, 4, 3, 4])
+SUITE["order_conditions"]["elementary_weight"] = @benchmarkable elementary_weight(
+    $t8, $rk4
+)
+
+# =============================================================================
+# Tree operations
+# =============================================================================
+
+SUITE["operations"] = BenchmarkGroup()
+
+SUITE["operations"]["subtrees"] = @benchmarkable sum(
+    _ -> 1.0, SubtreeIterator($t8)
+)
+SUITE["operations"]["splittings"] = @benchmarkable sum(
+    _ -> 1.0, all_splittings($t8)
+)
+SUITE["operations"]["order"] = @benchmarkable order.($trees7)
+SUITE["operations"]["symmetry"] = @benchmarkable σ.($trees7)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~10s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~10s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md